### PR TITLE
Attempt to fix ci job triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Deps
         run: python -m pip install -r requirements-dev.txt
       - name: Install and Run Tests
-        run: python -m unittest -s ./tests -t ./tests -v
+        run: python -m unittest discover -s ./tests -t ./tests -v
   lint:
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   tests:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
The repo was created with a main branch instead of master. However since
the CI was copied from an older repo using a master branch the triggers
weren't correcly set to use main. This commit attempts to fix this by
updating the trigger branches to be main.