### PR TITLE
Add quantum volume to backend configuration

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -162,6 +162,11 @@
                     "minItems": 0,
                     "description": "Instructions supported by the backend.",
                     "items": {"type": "string"}
+                    },
+                "quantum_volume": {
+                    "type": "integer",
+                    "description": "Backend quantum volume",
+                    "minimum": 1
                     }
                 }
             },


### PR DESCRIPTION
Add quantum volume to the backend configuration schema. The version remains unchanged since it's an existing field (the schema just never got updated). 