### PR TITLE
Add label to parametric pulse schema

### DIFF
--- a/schemas/examples/qasm_w_pulse_gates.json
+++ b/schemas/examples/qasm_w_pulse_gates.json
@@ -293,6 +293,7 @@
               "t0": 0,
               "ch": "d0",
               "pulse_shape": "gaussian",
+              "label": "pulse1",
               "parameters": {
                 "duration": 128,
                 "amp": [
@@ -307,6 +308,7 @@
               "t0": 128,
               "ch": "d0",
               "pulse_shape": "gaussian",
+              "label": "pulse1",
               "parameters": {
                 "duration": 128,
                 "amp": [
@@ -380,6 +382,7 @@
                   "t0": 0,
                   "ch": "d0",
                   "pulse_shape": "gaussian",
+                  "label": "pulse1",
                   "parameters": {
                     "duration": 128,
                     "amp": [

--- a/schemas/examples/qasm_w_pulse_gates.json
+++ b/schemas/examples/qasm_w_pulse_gates.json
@@ -293,7 +293,7 @@
               "t0": 0,
               "ch": "d0",
               "pulse_shape": "gaussian",
-              "label": "pulse1",
+              "label": "pulse_with_name_label",
               "parameters": {
                 "duration": 128,
                 "amp": [
@@ -308,7 +308,6 @@
               "t0": 128,
               "ch": "d0",
               "pulse_shape": "gaussian",
-              "label": "pulse1",
               "parameters": {
                 "duration": 128,
                 "amp": [
@@ -382,7 +381,21 @@
                   "t0": 0,
                   "ch": "d0",
                   "pulse_shape": "gaussian",
-                  "label": "pulse1",
+                  "label": "pulse_with_name_label",
+                  "parameters": {
+                    "duration": 128,
+                    "amp": [
+                      0.2,
+                      0
+                    ],
+                    "sigma": 16
+                  }
+                },
+                {
+                  "name": "parametric_pulse",
+                  "t0": 128,
+                  "ch": "d0",
+                  "pulse_shape": "gaussian",
                   "parameters": {
                     "duration": 128,
                     "amp": [

--- a/schemas/examples/qobj_openpulse_example.json
+++ b/schemas/examples/qobj_openpulse_example.json
@@ -37,7 +37,7 @@
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
             {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
             {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"},
-            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d1", "pulse_shape": "gaussian", "label":  "pulse_with_name_label"},
+            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d1", "pulse_shape": "gaussian", "label":  "pulse_with_name_label"}
             ]
         }
         ]

--- a/schemas/examples/qobj_openpulse_example.json
+++ b/schemas/examples/qobj_openpulse_example.json
@@ -36,7 +36,7 @@
             {"name": "copy", "register_orig": 1, "register_copy": [3,4]},
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
             {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
-            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"}
+            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian", "label":  "pulse2"}
             ]
         }
         ]

--- a/schemas/examples/qobj_openpulse_example.json
+++ b/schemas/examples/qobj_openpulse_example.json
@@ -36,7 +36,8 @@
             {"name": "copy", "register_orig": 1, "register_copy": [3,4]},
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
             {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
-            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian", "label":  "pulse2"}
+            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"},
+            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d1", "pulse_shape": "gaussian", "label":  "pulse_with_name_label"},
             ]
         }
         ]

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/qobj_schema.json",
     "description": "OpenQuantum quantum object data structure for running experiments",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "definitions": {
         "bfunc": {
             "properties": {

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -273,6 +273,7 @@
                                 "parametric_pulse"
                             ]
                         },
+                        "label": {"type": "string"},
                         "pulse_shape": {"type": "string"},
                         "parameters": {"type": "object"}
                     },


### PR DESCRIPTION
This PR adds `label` to parametric pulse schema.

See discussion in [Qiskit/qiskit-terra/#5365](https://github.com/Qiskit/qiskit-terra/pull/5365).
