### PR TITLE
Update backend schema with processor_type object

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -186,139 +186,140 @@
                         }
                     }
                 }
-            },
-            "openpulse_config":{
-                "required": ["open_pulse","n_uchannels","hamiltonian","u_channel_lo",
-                            "meas_levels","qubit_lo_range","meas_lo_range","dt","dtm",
-                            "rep_times", "meas_kernels","discriminators"],
-                "properties": {
-                            "open_pulse": {
-                                "enum": [ true ],
-                                "description": "The backend supports openPulse (true/false)"},
-                            "n_uchannels": {
-                                "type": "integer",
-                                "description": "Number of additional control channels",
-                                "minimum": 0},
-                            "hamiltonian": {
-                                "type": "object",
-                                "required": ["h_latex"],
-                                "description": "Hamiltonian of the backend",
-                                "properties": {
-                                    "h_latex": {
-                                        "type": "string",
-                                        "description": "The Hamiltonian in latex form"
-                                        },
-                                    "h_str": {
-                                        "type": "array",
-                                        "items": {"type": "string"},
-                                        "description": "The Hamiltonian in machine readable form"
-                                      },
-                                    "vars": {
-                                          "type": "object",
-                                          "description": "Variables in the h_str"},
-                                    "osc": {
-                                        "type": "object",
-                                        "description": "Number of levels for each oscillator mode"}
-                                      }
+            }
+        },
+        "openpulse_config":{
+            "required": ["open_pulse","n_uchannels","hamiltonian","u_channel_lo",
+                        "meas_levels","qubit_lo_range","meas_lo_range","dt","dtm",
+                        "rep_times", "meas_kernels","discriminators"],
+            "properties": {
+                        "open_pulse": {
+                            "enum": [ true ],
+                            "description": "The backend supports openPulse (true/false)"},
+                        "n_uchannels": {
+                            "type": "integer",
+                            "description": "Number of additional control channels",
+                            "minimum": 0},
+                        "hamiltonian": {
+                            "type": "object",
+                            "required": ["h_latex"],
+                            "description": "Hamiltonian of the backend",
+                            "properties": {
+                                "h_latex": {
+                                    "type": "string",
+                                    "description": "The Hamiltonian in latex form"
                                     },
-                            "u_channel_lo": {
-                                "type": "array",
-                                "minItems": 0,
-                                "description": "Relationship of the U Channel LO's in terms of the qubit LO's",
-                                "items": {
+                                "h_str": {
                                     "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "q": {"type": "integer"},
-                                            "scale": {"$ref": "#/definitions/complexnumber"}
-                                            }}
-                                        }
+                                    "items": {"type": "string"},
+                                    "description": "The Hamiltonian in machine readable form"
                                     },
-                            "meas_levels": {
-                                "type": "array",
-                                "minItems": 1,
-                                "maxitems": 3,
-                                "description": "Available measurement levels on the backend",
-                                "items": {"type": "integer", "minimum": 0, "maximum": 2}},
-                            "qubit_lo_range": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Frequency range for the qubit LO",
-                                "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
-                            "meas_lo_range": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Frequency range for the measurement LO",
-                                "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
-                            "dt": {
-                                "type": "number",
-                                "description": "Time discretization for the drive and U channels",
-                                "minimum": 0},
-                            "dtm": {
-                                "type": "number",
-                                "description": "Time discretization for the measurement channels",
-                                "minimum": 0},
-                            "rep_times": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Program execution times (microseconds) supported by backend.",
-                                "items": {"type": "number", "minimum": 0}},
-                            "meas_map": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Grouping of measurement which are multiplexed",
-                                "items": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}}},
-                            "channel_bandwidth": {
-                                "type": "array",
-                                "minItems": 2,
-                                "description": "Bandwidth of all channels (qubit,measurement and U)",
-                                "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
-                            "meas_kernels": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Available measurement kernels",
-                                "items": {"type": "string"}},
-                            "discriminators": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Available discriminators",
-                                "items": {"type": "string"}},
-                            "acquisition_latency": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Array of dimension n_qubits x n_registers. Latency (in units of dt) to write a measurement result from qubit n into register slot m.",
-                                "items": {"type": "array", "minItems": 1, "items": {"type": "integer"}}},
-                            "conditional_latency": {
-                                "type": "array",
-                                "minItems": 1,
-                                "description": "Array of dimension n_channels [d->u->m] x n_registers. Latency (in units of dt) to do a conditional operation on channel n from register slot m",
-                                "items": {"type": "array", "minItems": 1, "items": {"type": "number"}}},
-                            "parametric_pulses": {
-                                "type": "array",
-                                "minItems": 0,
-                                "description": "A list of available parametric pulse shapes",
-                                "items": {"type": "string"}},
-                            "channels": {
-                                "type": "object",
-                                "patternProperties": {
-                                    "^[a-z0-9]+$": {
+                                "vars": {
                                         "type": "object",
-                                        "properties": {
-                                            "type": {"type": "string"},
-                                            "purpose": {"type": "string"},
-                                            "operates": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "qubits": {"type": "array", "items": {"type": "integer", "minimum": 0}}
-                                                }
-                                            }
+                                        "description": "Variables in the h_str"},
+                                "osc": {
+                                    "type": "object",
+                                    "description": "Number of levels for each oscillator mode"}
+                                    }
+                                },
+                        "u_channel_lo": {
+                            "type": "array",
+                            "minItems": 0,
+                            "description": "Relationship of the U Channel LO's in terms of the qubit LO's",
+                            "items": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "q": {"type": "integer"},
+                                        "scale": {"$ref": "#/definitions/complexnumber"}
                                         }}
-                                    },
-                                "description": "A dictionary where each entry represents a channel configuration and contains configuration values such as the channel's mapping to qubits."
-                                }
-                            }},
+                                    }
+                                },
+                        "meas_levels": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxitems": 3,
+                            "description": "Available measurement levels on the backend",
+                            "items": {"type": "integer", "minimum": 0, "maximum": 2}},
+                        "qubit_lo_range": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Frequency range for the qubit LO",
+                            "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
+                        "meas_lo_range": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Frequency range for the measurement LO",
+                            "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
+                        "dt": {
+                            "type": "number",
+                            "description": "Time discretization for the drive and U channels",
+                            "minimum": 0},
+                        "dtm": {
+                            "type": "number",
+                            "description": "Time discretization for the measurement channels",
+                            "minimum": 0},
+                        "rep_times": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Program execution times (microseconds) supported by backend.",
+                            "items": {"type": "number", "minimum": 0}},
+                        "meas_map": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Grouping of measurement which are multiplexed",
+                            "items": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}}},
+                        "channel_bandwidth": {
+                            "type": "array",
+                            "minItems": 2,
+                            "description": "Bandwidth of all channels (qubit,measurement and U)",
+                            "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
+                        "meas_kernels": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Available measurement kernels",
+                            "items": {"type": "string"}},
+                        "discriminators": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Available discriminators",
+                            "items": {"type": "string"}},
+                        "acquisition_latency": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Array of dimension n_qubits x n_registers. Latency (in units of dt) to write a measurement result from qubit n into register slot m.",
+                            "items": {"type": "array", "minItems": 1, "items": {"type": "integer"}}},
+                        "conditional_latency": {
+                            "type": "array",
+                            "minItems": 1,
+                            "description": "Array of dimension n_channels [d->u->m] x n_registers. Latency (in units of dt) to do a conditional operation on channel n from register slot m",
+                            "items": {"type": "array", "minItems": 1, "items": {"type": "number"}}},
+                        "parametric_pulses": {
+                            "type": "array",
+                            "minItems": 0,
+                            "description": "A list of available parametric pulse shapes",
+                            "items": {"type": "string"}},
+                        "channels": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^[a-z0-9]+$": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {"type": "string"},
+                                        "purpose": {"type": "string"},
+                                        "operates": {
+                                            "type": "object",
+                                            "properties": {
+                                                "qubits": {"type": "array", "items": {"type": "integer", "minimum": 0}}
+                                            }
+                                        }
+                                    }}
+                                },
+                            "description": "A dictionary where each entry represents a channel configuration and contains configuration values such as the channel's mapping to qubits."
+                            }
+                        }},
         "gateconfig": {
             "type": "object",
             "required": ["name","parameters","qasm_def"],

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -174,15 +174,15 @@
                     "properties": {
                         "family": {
                             "type": "string",
-                            "description": "Processor family"
+                            "description": "Processor family of this processor"
                         },
                         "revision": {
                             "type": "number",
-                            "description": "Processor revision number"
+                            "description": "Revision number of this processor"
                         },
                         "segment": {
                             "type": "string",
-                            "description": "Processor family"
+                            "description": "Segment this processor belongs to within a larger chip"
                         }
                     }
                 }

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
     "description": "Qiskit device backend configuration",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "definitions": {
       "hamiltonian": {
           "type": "object",
@@ -167,7 +167,25 @@
                     "type": "integer",
                     "description": "Backend quantum volume",
                     "minimum": 1
-                    }
+                    },
+                "processor_type": {
+                    "type": "object",
+                    "required": ["family", "revision", "segment"],
+                    "properties": {
+                        "family": {
+                            "type": "string",
+                            "description": "Processor family"
+                            },
+                        "revision": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+$",
+                            "description": "Processor revision semvar"
+                          },
+                        "segment": {
+                            "type": "string",
+                            "description": "Processor family"
+                        }
+                }
                 }
             },
             "openpulse_config":{

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -175,12 +175,11 @@
                         "family": {
                             "type": "string",
                             "description": "Processor family"
-                            },
+                        },
                         "revision": {
-                            "type": "string",
-                            "pattern": "[a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+$",
-                            "description": "Processor revision semvar"
-                          },
+                            "type": "number",
+                            "description": "Processor revision number"
+                        },
                         "segment": {
                             "type": "string",
                             "description": "Processor family"

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -184,7 +184,7 @@
                             "type": "string",
                             "description": "Processor family"
                         }
-                }
+                    }
                 }
             },
             "openpulse_config":{

--- a/schemas/examples/backend_configuration_openpulse_example.json
+++ b/schemas/examples/backend_configuration_openpulse_example.json
@@ -56,5 +56,10 @@
     "discriminators": ["disc1","dis2"],
     "acquisition_latency": [[100,120],[90,150],[500,100]],
     "conditional_latency": [[200,200],[190,160],[500,100],[200,200],[190,160],[200,200],[190,160],[500,100]],
-    "parametric_pulses": ["constant", "gaussian_square", "gaussian"]
+    "parametric_pulses": ["constant", "gaussian_square", "gaussian"],
+    "processor_type": {
+        "family": "Canary",
+        "revision": "1.0.0",
+        "segment": "A"
+    }
 }

--- a/schemas/examples/backend_configuration_openpulse_example.json
+++ b/schemas/examples/backend_configuration_openpulse_example.json
@@ -59,7 +59,7 @@
     "parametric_pulses": ["constant", "gaussian_square", "gaussian"],
     "processor_type": {
         "family": "Canary",
-        "revision": "1.0.0",
+        "revision": 1.0,
         "segment": "A"
     }
 }

--- a/schemas/examples/backend_configuration_openqasm_example.json
+++ b/schemas/examples/backend_configuration_openqasm_example.json
@@ -37,5 +37,10 @@
     "credits_required": false,
     "open_pulse": false,
     "dt": 1.33,
-    "dtm": 10.5
+    "dtm": 10.5,
+    "processor_type": {
+        "family": "Canary",
+        "revision": "1.0.0",
+        "segment": "A"
+    }
 }

--- a/schemas/examples/backend_configuration_openqasm_example.json
+++ b/schemas/examples/backend_configuration_openqasm_example.json
@@ -40,7 +40,7 @@
     "dtm": 10.5,
     "processor_type": {
         "family": "Canary",
-        "revision": "1.0.0",
+        "revision": 1.0,
         "segment": "A"
     }
 }


### PR DESCRIPTION
This PR adds a `processor_type` object to the backend configuration schema. This will soon be returned by IBMQ  backends.