### PR TITLE
Update the revision key of processor_type

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
     "description": "Qiskit device backend configuration",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "definitions": {
       "hamiltonian": {
           "type": "object",
@@ -177,8 +177,8 @@
                             "description": "Processor family indicates quantum chip architecture"
                         },
                         "revision": {
-                            "type": "number",
-                            "description": "Revision number reflects design variants within a given processor family"
+                            "type": "string",
+                            "description": "Revision number reflects design variants within a given processor family. Is typically a semantic versioning value without the patch value, eg., \"1.0\"."
                         },
                         "segment": {
                             "type": "string",

--- a/schemas/examples/backend_configuration_openpulse_example.json
+++ b/schemas/examples/backend_configuration_openpulse_example.json
@@ -59,7 +59,7 @@
     "parametric_pulses": ["constant", "gaussian_square", "gaussian"],
     "processor_type": {
         "family": "Canary",
-        "revision": 1.0,
+        "revision": "1.0",
         "segment": "A"
     }
 }

--- a/schemas/examples/backend_configuration_openqasm_example.json
+++ b/schemas/examples/backend_configuration_openqasm_example.json
@@ -40,7 +40,7 @@
     "dtm": 10.5,
     "processor_type": {
         "family": "Canary",
-        "revision": 1.0,
+        "revision": "1.0",
         "segment": "A"
     }
 }


### PR DESCRIPTION
The initial description of the required schema was incorrect. This update mirrors what will be returned by the backend.