### PR TITLE
Allow LO freqs to be passed in qasm jobs

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -255,16 +255,6 @@
                             "maxitems": 3,
                             "description": "Available measurement levels on the backend",
                             "items": {"type": "integer", "minimum": 0, "maximum": 2}},
-                        "qubit_lo_range": {
-                            "type": "array",
-                            "minItems": 1,
-                            "description": "Frequency range for the qubit LO",
-                            "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
-                        "meas_lo_range": {
-                            "type": "array",
-                            "minItems": 1,
-                            "description": "Frequency range for the measurement LO",
-                            "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
                         "dt": {
                             "type": "number",
                             "description": "Time discretization for the drive and U channels",

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -185,6 +185,18 @@
                             "description": "Segment, if indicated, is used to distinguish different subsets of the qubit fabric/chip"
                         }
                     }
+                },
+                "qubit_lo_range": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Frequency range for the qubit LO",
+                    "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}
+                },
+                "meas_lo_range": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Frequency range for the measurement LO",
+                    "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}
                 }
             }
         },

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
     "description": "Qiskit device backend configuration",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "definitions": {
       "hamiltonian": {
           "type": "object",

--- a/schemas/examples/backend_configuration_openqasm_example.json
+++ b/schemas/examples/backend_configuration_openqasm_example.json
@@ -42,5 +42,7 @@
         "family": "Canary",
         "revision": "1.0",
         "segment": "A"
-    }
+    },
+    "qubit_lo_range": [[5,6],[5,6],[5,6]],
+    "meas_lo_range": [[6.5,7.5],[6.5,7.5],[6.5,7.5]]
 }

--- a/schemas/examples/backend_configuration_openqasm_simulator_example.json
+++ b/schemas/examples/backend_configuration_openqasm_simulator_example.json
@@ -24,5 +24,7 @@
     "max_shots": 8192,
     "open_pulse": false,
     "dt": 1.33,
-    "dtm": 10.5
+    "dtm": 10.5,
+    "qubit_lo_range": [[5,6],[5,6],[5,6]],
+    "meas_lo_range": [[6.5,7.5],[6.5,7.5],[6.5,7.5]]
 }

--- a/schemas/examples/backend_configuration_openqasm_simulator_example.json
+++ b/schemas/examples/backend_configuration_openqasm_simulator_example.json
@@ -24,7 +24,5 @@
     "max_shots": 8192,
     "open_pulse": false,
     "dt": 1.33,
-    "dtm": 10.5,
-    "qubit_lo_range": [[5,6],[5,6],[5,6]],
-    "meas_lo_range": [[6.5,7.5],[6.5,7.5],[6.5,7.5]]
+    "dtm": 10.5
 }

--- a/schemas/examples/qobj_openqasm_example.json
+++ b/schemas/examples/qobj_openqasm_example.json
@@ -8,7 +8,9 @@
     "config": {
         "shots": 1024,
         "memory_slots": 1,
-        "init_qubits": true
+        "init_qubits": true,
+        "qubit_lo_freq": [5.5, 5.5, 5.5],
+        "meas_lo_freq": [6.7, 6.7, 6.7]
         },
     "experiments": [
         {
@@ -48,6 +50,5 @@
             {"name": "u1", "qubits": [1], "params": [0.4], "conditional": 2}
             ]
         }
-        ]    
+        ]
 }
-

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -1214,15 +1214,6 @@
                                 2
                             ]
                         },
-                        "meas_lo_freq": {
-                            "description": "Measurement LO frequencies",
-                            "items": {
-                                "minimum": 0,
-                                "type": "number"
-                            },
-                            "minItems": 1,
-                            "type": "array"
-                        },
                         "meas_return": {
                             "description": "Return each shot of data or average over the shots",
                             "enum": [
@@ -1238,15 +1229,6 @@
                         },
                         "pulse_library": {
                             "$ref": "#/definitions/pulse_library"
-                        },
-                        "qubit_lo_freq": {
-                            "description": "Qubit drive LO frequencies",
-                            "items": {
-                                "minimum": 0,
-                                "type": "number"
-                            },
-                            "minItems": 1,
-                            "type": "array"
                         },
                         "rep_time": {
                             "minimum": 1,

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -1134,6 +1134,24 @@
                                     }
                                 }
                             }
+                        },
+                        "qubit_lo_freq": {
+                            "description": "Qubit drive LO frequencies",
+                            "items": {
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                        },
+                        "meas_lo_freq": {
+                            "description": "Measurement LO frequencies",
+                            "items": {
+                                "minimum": 0,
+                                "type": "number"
+                            },
+                            "minItems": 1,
+                            "type": "array"
                         }
                     },
                     "title": "Qobj-level configuration",

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/qobj_schema.json",
     "description": "OpenQuantum quantum object data structure for running experiments",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "definitions": {
         "bfunc": {
             "properties": {


### PR DESCRIPTION
## Summary
Part of https://github.com/Qiskit/qiskit-terra/issues/5874 to allow LO frequencies to be passed in qasm jobs. Will work in conjunction with https://github.com/Qiskit/qiskit-terra/pull/6167/files.

## Details
-Update `backend_configuration_schema.json` to return `qubit_lo_range/meas_lo_range` in qasm jobs as an optional parameter (if backend returns it)
-Update `qobj_schema.json` to allow `qubit_lo_freq/meas_lo_freq` to be passed in the configuration of qobj jobs