### PR TITLE
Add `measure_esp_enabled` to backend configuration 

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
     "description": "Qiskit device backend configuration",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "definitions": {
       "hamiltonian": {
           "type": "object",

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -157,6 +157,11 @@
                     "description": "Whether delay between programs can be set dynamically using 'rep_delay').",
                     "default": false
                     },
+                "measure_esp_enabled": {
+                    "type": "boolean",
+                    "description": "Whether ESP readout is supported by the backend.",
+                    "default": false
+                    },
                 "supported_instructions": {
                     "type": "array",
                     "minItems": 0,


### PR DESCRIPTION
Add the `measure_esp_enabled` flag to `backend_configuration_schema.json`. This is an optional flag. Should be merged in conjunction with https://github.com/Qiskit/qiskit-terra/pull/6543/files.