### PR TITLE
Add timing constraints

### DIFF
--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
     "description": "Qiskit device backend configuration",
-    "version": "1.4.4",
+    "version": "1.5.4",
     "definitions": {
       "hamiltonian": {
           "type": "object",
@@ -202,6 +202,28 @@
                     "minItems": 1,
                     "description": "Frequency range for the measurement LO",
                     "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}
+                },
+                "timing_constraints": {
+                    "type": "object",
+                    "required": ["granularity", "min_length", "pulse_alignment", "acquire_alignment"],
+                    "properties": {
+                        "granularity": {
+                            "type": "integer",
+                            "description": "Waveform memory data chunk size"
+                        },
+                        "min_length": {
+                            "type": "integer",
+                            "description": "Minimum number of samples required to define a pulse"
+                        },
+                        "pulse_alignment": {
+                            "type": "integer",
+                            "description": "Instruction triggering time resolution of pulse channel in units of dt"
+                        },
+                        "acquire_alignment": {
+                            "type": "integer",
+                            "description": "Instruction triggering time resolution of acquisition channel in units of dt"
+                        }
+                    }
                 }
             }
         },

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -205,7 +205,6 @@
                 },
                 "timing_constraints": {
                     "type": "object",
-                    "required": ["granularity", "min_length", "pulse_alignment", "acquire_alignment"],
                     "properties": {
                         "granularity": {
                             "type": "integer",

--- a/schemas/examples/backend_configuration_openpulse_example.json
+++ b/schemas/examples/backend_configuration_openpulse_example.json
@@ -61,5 +61,11 @@
         "family": "Canary",
         "revision": "1.0",
         "segment": "A"
+    },
+    "timing_constraints": {
+        "granularity": 16,
+        "min_length": 64,
+        "pulse_alignment": 1,
+        "acquire_alignment": 16
     }
 }

--- a/schemas/examples/backend_configuration_openqasm_example.json
+++ b/schemas/examples/backend_configuration_openqasm_example.json
@@ -44,5 +44,11 @@
         "segment": "A"
     },
     "qubit_lo_range": [[5,6],[5,6],[5,6]],
-    "meas_lo_range": [[6.5,7.5],[6.5,7.5],[6.5,7.5]]
+    "meas_lo_range": [[6.5,7.5],[6.5,7.5],[6.5,7.5]],
+    "timing_constraints": {
+        "granularity": 16,
+        "min_length": 64,
+        "pulse_alignment": 1,
+        "acquire_alignment": 16
+    }
 }


### PR DESCRIPTION
This PR adds new configuration field `timing_constraints` to ibm backends. This information is required to control pulse gate and circuit with delay from the Qiskit. See https://github.com/Qiskit/qiskit-terra/pull/6705 for details.