### PR TITLE
PrimitivesV2 schemas

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ fastjsonschema
 jsonschema
 jsonschema-rs
 ddt
-qiskit-ibm-runtime>=0.22
+qiskit-ibm-runtime@git+ssh://git@github.com/Qiskit/qiskit-ibm-runtime.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ fastjsonschema
 jsonschema
 jsonschema-rs
 ddt
-qiskit-ibm-runtime>=0.23
+qiskit-ibm-runtime@git+https://git@github.com/Qiskit/qiskit-ibm-runtime.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ fastjsonschema
 jsonschema
 jsonschema-rs
 ddt
-qiskit-ibm-runtime@git+https://git@github.com/Qiskit/qiskit-ibm-runtime.git
+qiskit-ibm-runtime>=0.23

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ fastjsonschema
 jsonschema
 jsonschema-rs
 ddt
-qiskit-ibm-runtime@git+ssh://git@github.com/Qiskit/qiskit-ibm-runtime.git
+qiskit-ibm-runtime@git+https://git@github.com/Qiskit/qiskit-ibm-runtime.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ fastjsonschema
 jsonschema
 jsonschema-rs
 ddt
+qiskit-ibm-runtime>=0.22

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -167,7 +167,7 @@
                                 "max_overhead": {
                                     "description": "The maximum circuit sampling overhead allowed",
                                     "oneOf": [
-                                      {"type": "number"},
+                                      {"type": "number", "exclusiveMinimum": 0},
                                       {"type": "null"}
                                     ]
                                 },

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -14,7 +14,7 @@
                 "type": "array",
                 "prefixItems": [
                     {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
-                    {"description": "The observable array", "type": "object"},
+                    {"description": "One or more observables.", "type": "array"},
                     {"description": "The parameter values", "type": "object"}
                 ]
             }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -75,6 +75,51 @@
                     "type": "number"
                 }
             }
+        },
+        "execution": {
+            "description": "Execution options",
+            "type": "object",
+            "properties": {
+                "shots": {
+                    "description": "Number of repetitions of each circuit, for sampling",
+                    "type": "number"
+                },
+                "init_qubits": {
+                    "description": "Whether to reset the qubits to the ground state for each shot",
+                    "type": "boolean"
+                },
+                "samples": {
+                    "description": "The number of samples of each measurement circuit to run",
+                    "type": "number"
+                },
+                "shots_per_sample": {
+                    "description": "The number of shots per sample of each measurement circuit to run",
+                    "type": "number"
+                },
+                 "interleave_samples": {
+                    "description": "Whether to interleave samples from different measurement circuits when running or run them in order",
+                    "type": "boolean"
+                }
+            }
+        },
+        "twirling": {
+            "description": "Twirling options",
+            "type": "object",
+            "properties": {
+                "gates": {
+                    "description": "Whether to apply 2-qubit gate twirling",
+                    "type": "boolean"
+                },
+                "measure": {
+                    "description": "Whether to apply measurement twirling",
+                    "type": "boolean"
+                },
+                 "strategy": {
+                    "description": "The strategy of twirling qubits in identified layers of 2-qubit twirled gates",
+                    "type": "string",
+                    "enum": ["active", "active-circuit", "active-accum", "all"]
+                }
+            }
         }
     }
 }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://www.qiskit.org/schemas/estimator_v2_schema.json",
+    "title": "EstimatorV2 input",
+    "description": "The input for an EstimatorV2 API call",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["pubs"],
+    "properties": {
+        "pubs": {
+            "type": "array",
+            "description": "Circuits/Observbles/Parameters to run",
+            "items": {
+                "type": "array",
+                "prefixItems": [
+                    {"description": "The quantum circuit", "type": "object"},
+                    {"description": "The observable array", "type": "object"},
+                    {"description": "The parameter values", "type": "object"}
+                ]
+            }
+        },
+        "transpilation": {
+          "description": "Transpilation settings.",
+          "type": "object",
+          "properties": {
+              "optimization_level": {
+                "description": "How much optimization to perform on the circuits",
+                "type": "integer",
+                "enum": [0, 1]
+              }
+          }
+        },
+        "resilience_level": {
+            "description": "How much resilience to build against errors",
+            "type": "integer",
+            "enum": [0, 1, 2]
+        },
+        "resilience": {
+            "description": "Advanced resilience options to fine tune the resilience strategy",
+            "type": "object",
+            "properties": {
+                "measure_noise_mitigation": {
+                    "description": "Whether to enable measurement error mitigation method",
+                    "type": "boolean"
+                },
+                "zne_mitigation": {
+                    "description": "Whether to turn on Zero Noise Extrapolation error mitigation method",
+                    "type": "boolean"
+                },
+                "zne_noise_factors": {
+                    "description": "A list of real valued noise factors that determine by what amount the circuits' noise is amplified",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "zne_extrapolator": {
+                    "description": "A list of extrapolation strategies",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
+                        }
+                    ]
+                },
+                "zne_stderr_threshold": {
+                    "description": "A standard error threshold for accepting the ZNE result",
+                    "type": "number"
+                }
+            }
+        }
+    }
+}

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -186,7 +186,8 @@
                             "properties": {
                                 "max_layers_to_learn": {
                                     "description": "The max number of unique layers to learn",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "minimum": 0
                                 },
                                 "shots_per_randomization": {
                                     "description": "The total number of shots to use per random learning circuit",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -196,7 +196,8 @@
                                 },
                                 "num_randomizations": {
                                     "description": "The number of random circuits to use per learning circuit configuration",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "minimum": 1
                                 },
                                 "layer_pair_depths": {
                                     "description": "The circuit depths (measured in number of pairs) to use in learning experiments",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -97,7 +97,15 @@
                                 },
                                 "shots_per_randomization": {
                                     "description": "The number of shots to use for the learning experiment per random circuit.",
-                                    "oneOf": [{"type": "integer", "minimum": 1}, {"enum": "auto"}]
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1
+                                        },
+                                        {
+                                            "enum": "auto"
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -167,15 +175,27 @@
                                 "max_overhead": {
                                     "description": "The maximum circuit sampling overhead allowed",
                                     "oneOf": [
-                                      {"type": "number", "exclusiveMinimum": 0},
-                                      {"type": "null"}
+                                        {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
                                     ]
                                 },
                                 "noise_gain": {
                                     "description": "The amount by which to scale the noise",
                                     "oneOf": [
-                                        {"type":  "number", "exclusiveMinimum": 0},
-                                        {"enum":  ["auto"]}
+                                        {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0
+                                        },
+                                        {
+                                            "enum": [
+                                                "auto"
+                                            ]
+                                        }
                                     ]
                                 }
                             }
@@ -209,8 +229,25 @@
                                 }
                             }
                         }
-
-                    }
+                    },
+                    "allOf": [
+                        {
+                            "not": {
+                                "required": [
+                                    "zne_mitigation",
+                                    "pec_mitigation"
+                                ],
+                                "properties": {
+                                    "zne_mitigation": {
+                                        "const": true
+                                    },
+                                    "pec_mitigation": {
+                                        "const": true
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 },
                 "execution": {
                     "description": "Execution options",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -13,7 +13,7 @@
             "items": {
                 "type": "array",
                 "prefixItems": [
-                    {"description": "The quantum circuit", "type": "object"},
+                    {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
                     {"description": "The observable array", "type": "object"},
                     {"description": "The parameter values", "type": "object"}
                 ]

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -12,10 +12,12 @@
             "description": "Circuits/Observbles/Parameters to run",
             "items": {
                 "type": "array",
+                "minItems": 2,
                 "prefixItems": [
                     {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
                     {"description": "One or more observables.", "type": "array"},
-                    {"description": "The parameter values", "type": "object"}
+                    {"description": "The parameter values", "type": "object"},
+                    {"description": "The precision for this specific pub", "type": "number"}
                 ]
             }
         },
@@ -73,15 +75,6 @@
                             ]
                         }
                     }
-                },
-                "resilience_level": {
-                    "description": "How much resilience to build against errors",
-                    "type": "integer",
-                    "enum": [
-                        0,
-                        1,
-                        2
-                    ]
                 },
                 "resilience": {
                     "description": "Advanced resilience options to fine tune the resilience strategy",
@@ -259,6 +252,19 @@
                     }
                 }
             }
+        },
+        "resilience_level": {
+                    "description": "How much resilience to build against errors",
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
+                    ]
+                },
+        "version": {
+            "description": "For EstimatorV2, version should always be 2",
+            "enum": [2]
         }
     }
 }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -422,7 +422,7 @@
                                     "oneOf": [
                                         {
                                             "type": "number",
-                                            "exclusiveMinimum": 0
+                                            "minimum": 0
                                         },
                                         {
                                             "enum": [

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -19,109 +19,244 @@
                 ]
             }
         },
-        "seed_estimator": {
-            "description": "Seed used to control sampling",
-            "type": "integer"
-        },
-        "transpilation": {
-          "description": "Transpilation settings",
-          "type": "object",
-          "properties": {
-              "optimization_level": {
-                "description": "How much optimization to perform on the circuits",
-                "type": "integer",
-                "enum": [0, 1]
-              }
-          }
-        },
-        "resilience_level": {
-            "description": "How much resilience to build against errors",
-            "type": "integer",
-            "enum": [0, 1, 2]
-        },
-        "resilience": {
-            "description": "Advanced resilience options to fine tune the resilience strategy",
+        "options": {
             "type": "object",
+            "description": "Options for V2 Estimator",
             "properties": {
-                "measure_noise_mitigation": {
-                    "description": "Whether to enable measurement error mitigation method",
-                    "type": "boolean"
+                "seed_estimator": {
+                    "description": "Seed used to control sampling",
+                    "type": "integer"
                 },
-                "zne_mitigation": {
-                    "description": "Whether to turn on Zero Noise Extrapolation error mitigation method",
-                    "type": "boolean"
+                "default_precision": {
+                    "description": "The default precision to use for any PUB that does not specify one",
+                    "type": "number"
                 },
-                "zne_noise_factors": {
-                    "description": "A list of real valued noise factors that determine by what amount the circuits' noise is amplified",
-                    "type": "array",
-                    "items": {
-                        "type": "number"
+                "default_shots": {
+                    "description": "The total number of shots to use per circuit per configuration",
+                    "type": "integer"
+                },
+                "dynamical_decoupling": {
+                    "description": "Suboptions for dynamical decoupling",
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "description": "Whether to enable DD as specified by the other options in this class",
+                            "type": "boolean"
+                        },
+                        "sequence_type": {
+                            "description": "Which dynamical decoupling sequence to use",
+                            "type": "string",
+                            "enum": ["XX", "XpXm", "XY4"]
+                        },
+                        "extra_slack_distribution": {
+                            "description": "Where to put extra timing delays due to rounding issues",
+                            "type": "string",
+                            "enum": ["middle", "edges"]
+                        },
+                        "scheduling_method": {
+                            "description": "Whether to schedule gates as soon as ('asap') or as late as ('alap') possible",
+                            "type": "string",
+                            "enum": ["alap", "asap"]
+                        }
                     }
                 },
-                "zne_extrapolator": {
-                    "description": "A list of extrapolation strategies",
-                    "oneOf": [
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
-                            }
-                        },
-                        {
-                            "type": "string",
-                            "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
+                "transpilation": {
+                    "description": "Transpilation settings",
+                    "type": "object",
+                    "properties": {
+                        "optimization_level": {
+                            "description": "How much optimization to perform on the circuits",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1
+                            ]
                         }
+                    }
+                },
+                "resilience_level": {
+                    "description": "How much resilience to build against errors",
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
                     ]
                 },
-                "zne_stderr_threshold": {
-                    "description": "A standard error threshold for accepting the ZNE result",
-                    "type": "number"
-                }
-            }
-        },
-        "execution": {
-            "description": "Execution options",
-            "type": "object",
-            "properties": {
-                "shots": {
-                    "description": "Number of repetitions of each circuit, for sampling",
-                    "type": "number"
+                "resilience": {
+                    "description": "Advanced resilience options to fine tune the resilience strategy",
+                    "type": "object",
+                    "properties": {
+                        "measure_mitigation": {
+                            "description": "Whether to enable measurement error mitigation method",
+                            "type": "boolean"
+                        },
+                        "measure_noise_learning": {
+                            "description": "Additional measurement noise learning options",
+                            "type": "object",
+                            "properties": {
+                                "num_randomizations": {
+                                    "description": "The number of random circuits to draw for the measurement learning experiment",
+                                    "type": "integer"
+                                },
+                                "shots_per_randomization": {
+                                    "description": "The number of shots to use for the learning experiment per random circuit.",
+                                    "oneOf": [{"type": "integer"}, {"enum": "auto"}]
+                                }
+                            }
+                        },
+                        "zne_mitigation": {
+                            "description": "Whether to turn on Zero Noise Extrapolation error mitigation method",
+                            "type": "boolean"
+                        },
+                        "zne": {
+                            "description": "Additional zero noise extrapolation mitigation options",
+                            "type": "object",
+                            "properties": {
+                                "zne_noise_factors": {
+                                    "description": "Noise factors to use for noise amplification",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "number"
+                                    }
+                                },
+                                "zne_extrapolator": {
+                                    "description": "Extrapolator(s) to try (in order) for extrapolating to zero noise",
+                                    "oneOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "linear",
+                                                    "exponential",
+                                                    "double_exponential",
+                                                    "polynomial_degree_1",
+                                                    "polynomial_degree_2",
+                                                    "polynomial_degree_3",
+                                                    "polynomial_degree_4",
+                                                    "polynomial_degree_5",
+                                                    "polynomial_degree_6",
+                                                    "polynomial_degree_7"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "linear",
+                                                "exponential",
+                                                "double_exponential",
+                                                "polynomial_degree_1",
+                                                "polynomial_degree_2",
+                                                "polynomial_degree_3",
+                                                "polynomial_degree_4",
+                                                "polynomial_degree_5",
+                                                "polynomial_degree_6",
+                                                "polynomial_degree_7"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "pec_mitigation": {
+                            "description": "Whether to turn on Probabilistic Error Cancellation error mitigation method",
+                            "type": "boolean"
+                        },
+                        "pec": {
+                            "description": "Additional probabalistic error cancellation mitigation options",
+                            "type": "object",
+                            "properties": {
+                                "max_overhead": {
+                                    "description": "The maximum circuit sampling overhead allowed",
+                                    "oneOf": [
+                                      {"type": "number"},
+                                      {"type": "null"}
+                                    ]
+                                },
+                                "noise_gain": {
+                                    "description": "The amount by which to scale the noise",
+                                    "oneOf": [
+                                        {"type":  "numebr"},
+                                        {"enum":  ["auto"]}
+                                    ]
+                                }
+                            }
+                        },
+                        "layer_noise_learning": {
+                            "description": "Layer noise learning options",
+                            "type": "object",
+                            "properties": {
+                                "max_layers_to_learn": {
+                                    "description": "The max number of unique layers to learn",
+                                    "type": "integer"
+                                },
+                                "shots_per_randomization": {
+                                    "description": "The total number of shots to use per random learning circuit",
+                                    "type": "integer"
+                                },
+                                "num_randomizations": {
+                                    "description": "The number of random circuits to use per learning circuit configuration",
+                                    "type": "integer"
+                                },
+                                "layer_pair_depths": {
+                                    "description": "The circuit depths (measured in number of pairs) to use in learning experiments",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
+                        }
+
+                    }
                 },
-                "init_qubits": {
-                    "description": "Whether to reset the qubits to the ground state for each shot",
-                    "type": "boolean"
+                "execution": {
+                    "description": "Execution options",
+                    "type": "object",
+                    "properties": {
+                        "init_qubits": {
+                            "description": "Whether to reset the qubits to the ground state for each shot",
+                            "type": "boolean"
+                        },
+                        "rep_delay": {
+                            "description": "The delay between a measurement and the subsequent quantum circuit",
+                            "type": "number"
+                        }
+                    }
                 },
-                "samples": {
-                    "description": "The number of samples of each measurement circuit to run",
-                    "type": "number"
-                },
-                "shots_per_sample": {
-                    "description": "The number of shots per sample of each measurement circuit to run",
-                    "type": "number"
-                },
-                 "interleave_samples": {
-                    "description": "Whether to interleave samples from different measurement circuits when running or run them in order",
-                    "type": "boolean"
-                }
-            }
-        },
-        "twirling": {
-            "description": "Twirling options",
-            "type": "object",
-            "properties": {
-                "gates": {
-                    "description": "Whether to apply 2-qubit gate twirling",
-                    "type": "boolean"
-                },
-                "measure": {
-                    "description": "Whether to apply measurement twirling",
-                    "type": "boolean"
-                },
-                 "strategy": {
-                    "description": "The strategy of twirling qubits in identified layers of 2-qubit twirled gates",
-                    "type": "string",
-                    "enum": ["active", "active-circuit", "active-accum", "all"]
+                "twirling": {
+                    "description": "Twirling options",
+                    "type": "object",
+                    "properties": {
+                        "enable_gates": {
+                            "description": "Whether to apply 2-qubit gate twirling",
+                            "type": "boolean"
+                        },
+                        "enable_measure": {
+                            "description": "Whether to apply measurement twirling",
+                            "type": "boolean"
+                        },
+                        "num_randomizations": {
+                            "description": "The number of random samples to use when twirling or performing sampled mitigation",
+                            "oneOf": [{"type": "integer"}, {"enum": ["auto"]}]
+                        },
+                        "shots_per_randomization": {
+                            "description": "The number of shots to run for each random sample",
+                            "oneOf": [{"type": "integer"}, {"enum": ["auto"]}]
+                        },
+                        "strategy": {
+                            "description": "The strategy of twirling qubits in identified layers of 2-qubit twirled gates",
+                            "type": "string",
+                            "enum": [
+                                "active",
+                                "active-circuit",
+                                "active-accum",
+                                "all"
+                            ]
+                        }
+                    }
                 }
             }
         }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -40,7 +40,7 @@
                     "type": "object",
                     "properties": {
                         "enable": {
-                            "description": "Whether to enable DD as specified by the other options in this class",
+                            "description": "Whether to enable dynamical decoupling.",
                             "type": "boolean"
                         },
                         "sequence_type": {

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -14,7 +14,7 @@
                 "type": "array",
                 "minItems": 2,
                 "prefixItems": [
-                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
+                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": ["object", "string"]},
                     {"description": "One or more observables, which can be given as strings.", "type": "array"},
                     {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The precision for this specific pub", "type": "number"}

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -397,6 +397,7 @@
                                 }
                             ]
                         },
+
                         "pec_mitigation": {
                             "description": "Whether to turn on Probabilistic Error Cancellation error mitigation method",
                             "type": "boolean"
@@ -475,6 +476,40 @@
                                         "const": true
                                     },
                                     "pec_mitigation": {
+                                        "const": true
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "$comment": "measure noise learning options requires measure_mitigation=True",
+                                "properties": {
+                                    "measure_noise_learning": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "measure_mitigation": {
+                                        "const": true
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "$comment": "zne options requires zne_mitigation=True",
+                                "properties": {
+                                    "zne": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "zne_mitigation": {
                                         "const": true
                                     }
                                 }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -16,7 +16,7 @@
                 "prefixItems": [
                     {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
                     {"description": "One or more observables.", "type": "array"},
-                    {"description": "The parameter values", "type": "object"},
+                    {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The precision for this specific pub", "type": "number"}
                 ]
             }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -397,7 +397,6 @@
                                 }
                             ]
                         },
-
                         "pec_mitigation": {
                             "description": "Whether to turn on Probabilistic Error Cancellation error mitigation method",
                             "type": "boolean"

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -103,7 +103,7 @@
                                             "minimum": 1
                                         },
                                         {
-                                            "enum": "auto"
+                                            "enum": ["auto"]
                                         }
                                     ]
                                 }
@@ -117,14 +117,14 @@
                             "description": "Additional zero noise extrapolation mitigation options",
                             "type": "object",
                             "properties": {
-                                "zne_noise_factors": {
+                                "noise_factors": {
                                     "description": "Noise factors to use for noise amplification",
                                     "type": "array",
                                     "items": {
                                         "type": "number"
                                     }
                                 },
-                                "zne_extrapolator": {
+                                "extrapolator": {
                                     "description": "Extrapolator(s) to try (in order) for extrapolating to zero noise",
                                     "oneOf": [
                                         {
@@ -162,7 +162,240 @@
                                         }
                                     ]
                                 }
-                            }
+                            },
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "$comment": "linear, exponential and polynomial_degree_1 require at least 2 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "anyOf": [
+                                                            {"const": "linear"},
+                                                            {"const": "exponential"},
+                                                            {"const": "polynomial_degree_1"}
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "anyOf": [
+                                                                {"const": "linear"},
+                                                                {"const": "exponential"},
+                                                                {"const": "polynomial_degree_1"}
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 2
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "$comment": "polynomial_degree_2 requires at least 3 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "const": "polynomial_degree_2"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "const": "polynomial_degree_2"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 3
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "$comment": "double_exponential and polynomial_degree_3 require at least 4 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "anyOf": [
+                                                            {"const": "double_exponential"},
+                                                            {"const": "polynomial_degree_3"}
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "anyOf": [
+                                                                {"const": "double_exponential"},
+                                                                {"const": "polynomial_degree_3"}
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 4
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "$comment": "polynomial_degree_4 requires at least 5 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "const": "polynomial_degree_4"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "const": "polynomial_degree_4"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 5
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "$comment": "polynomial_degree_5 requires at least 6 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "const": "polynomial_degree_5"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "const": "polynomial_degree_5"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 6
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "$comment": "polynomial_degree_6 requires at least 7 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "const": "polynomial_degree_6"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "const": "polynomial_degree_6"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 7
+                                            }
+                                        }
+                                    }
+                                },
+                                 {
+                                    "if": {
+                                        "$comment": "polynomial_degree_7 requires at least 8 noise factors",
+                                        "anyOf": [
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "const": "polynomial_degree_7"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "properties": {
+                                                    "extrapolator": {
+                                                        "type": "array",
+                                                        "contains": {
+                                                            "const": "polynomial_degree_7"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "noise_factors": {
+                                                "minItems": 8
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         },
                         "pec_mitigation": {
                             "description": "Whether to turn on Probabilistic Error Cancellation error mitigation method",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -244,7 +244,7 @@
                         },
                         "shots_per_randomization": {
                             "description": "The number of shots to run for each random sample",
-                            "oneOf": [{"type": "integer"}, {"enum": ["auto"]}]
+                            "oneOf": [{"type": "integer", "minimum": 1}, {"enum": ["auto"]}]
                         },
                         "strategy": {
                             "description": "The strategy of twirling qubits in identified layers of 2-qubit twirled gates",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -594,6 +594,10 @@
                     "description": "Default precision level which applies to all pubs without precision",
                     "type": "number"
                 },
+        "support_qiskit": {
+            "description": "If True, returns a qiskit-style output, meant to be parsed using the runtime result decoder, or resort to returning pure JSON results (resulting in larger objects)",
+            "type": "bool"
+        },
         "version": {
             "description": "For EstimatorV2, version should always be 2",
             "enum": [2]

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -191,7 +191,8 @@
                                 },
                                 "shots_per_randomization": {
                                     "description": "The total number of shots to use per random learning circuit",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "minimum": 1
                                 },
                                 "num_randomizations": {
                                     "description": "The number of random circuits to use per learning circuit configuration",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -590,6 +590,10 @@
                         2
                     ]
                 },
+        "precision": {
+                    "description": "Default precision level which applies to all pubs without precision",
+                    "type": "number"
+                },
         "version": {
             "description": "For EstimatorV2, version should always be 2",
             "enum": [2]

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -91,7 +91,8 @@
                             "properties": {
                                 "num_randomizations": {
                                     "description": "The number of random circuits to draw for the measurement learning experiment",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "minimum": 1
                                 },
                                 "shots_per_randomization": {
                                     "description": "The number of shots to use for the learning experiment per random circuit.",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -174,7 +174,7 @@
                                 "noise_gain": {
                                     "description": "The amount by which to scale the noise",
                                     "oneOf": [
-                                        {"type":  "numebr"},
+                                        {"type":  "number", "exclusiveMinimum": 0},
                                         {"enum":  ["auto"]}
                                     ]
                                 }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -240,7 +240,7 @@
                         },
                         "num_randomizations": {
                             "description": "The number of random samples to use when twirling or performing sampled mitigation",
-                            "oneOf": [{"type": "integer"}, {"enum": ["auto"]}]
+                            "oneOf": [{"type": "integer", "minimum": 1}, {"enum": ["auto"]}]
                         },
                         "shots_per_randomization": {
                             "description": "The number of shots to run for each random sample",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -403,7 +403,7 @@
                             "type": "boolean"
                         },
                         "pec": {
-                            "description": "Additional probabalistic error cancellation mitigation options",
+                            "description": "Additional probabilistic error cancellation mitigation options",
                             "type": "object",
                             "properties": {
                                 "max_overhead": {
@@ -510,6 +510,23 @@
                             "then": {
                                 "properties": {
                                     "zne_mitigation": {
+                                        "const": true
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "$comment": "pec options requires pec_mitigation=True",
+                                "properties": {
+                                    "pec": {
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "pec_mitigation": {
                                         "const": true
                                     }
                                 }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -9,13 +9,13 @@
     "properties": {
         "pubs": {
             "type": "array",
-            "description": "Circuits/Observbles/Parameters to run",
+            "description": "Primitive Unit Blocs of data. Each PUB is of the form (Circuit, Observables, Parameters, Precision) where the circuit and observables are required, parameters should be passed only for parametrized circuits, and precision is optional",
             "items": {
                 "type": "array",
                 "minItems": 2,
                 "prefixItems": [
-                    {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
-                    {"description": "One or more observables.", "type": "array"},
+                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
+                    {"description": "One or more observables, which can be given as strings.", "type": "array"},
                     {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The precision for this specific pub", "type": "number"}
                 ]

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -35,7 +35,8 @@
                 },
                 "default_shots": {
                     "description": "The total number of shots to use per circuit per configuration",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "dynamical_decoupling": {
                     "description": "Suboptions for dynamical decoupling",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -203,7 +203,8 @@
                                     "description": "The circuit depths (measured in number of pairs) to use in learning experiments",
                                     "type": "array",
                                     "items": {
-                                        "type": "integer"
+                                        "type": "integer",
+                                        "minimum": 0
                                     }
                                 }
                             }

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -97,7 +97,7 @@
                                 },
                                 "shots_per_randomization": {
                                     "description": "The number of shots to use for the learning experiment per random circuit.",
-                                    "oneOf": [{"type": "integer"}, {"enum": "auto"}]
+                                    "oneOf": [{"type": "integer", "minimum": 1}, {"enum": "auto"}]
                                 }
                             }
                         },

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -31,7 +31,8 @@
                 },
                 "default_precision": {
                     "description": "The default precision to use for any PUB that does not specify one",
-                    "type": "number"
+                    "type": "number",
+                    "exclusiveMinimum": 0
                 },
                 "default_shots": {
                     "description": "The total number of shots to use per circuit per configuration. If set, this value overrides default_precision.",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -34,7 +34,7 @@
                     "type": "number"
                 },
                 "default_shots": {
-                    "description": "The total number of shots to use per circuit per configuration",
+                    "description": "The total number of shots to use per circuit per configuration. If set, this value overrides default_precision.",
                     "type": "integer",
                     "minimum": 0
                 },

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -596,7 +596,7 @@
                 },
         "support_qiskit": {
             "description": "If True, returns a qiskit-style output, meant to be parsed using the runtime result decoder, or resort to returning pure JSON results (resulting in larger objects)",
-            "type": "bool"
+            "type": "boolean"
         },
         "version": {
             "description": "For EstimatorV2, version should always be 2",

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -12,9 +12,11 @@
             "description": "Circuits/Parameters to run",
             "items": {
                 "type": "array",
+                "minItems": 1,
                 "prefixItems": [
                     {"description": "The quantum circuit", "type": "object"},
-                    {"description": "The parameter values", "type": "object"}
+                    {"description": "The parameter values", "type": "object"},
+                    {"description": "The numebr of shots to use in this pub", "type": "integer"}
                 ]
             }
         },
@@ -51,20 +53,6 @@
                         }
                     }
                 },
-                "transpilation": {
-                    "description": "Transpilation settings",
-                    "type": "object",
-                    "properties": {
-                        "optimization_level": {
-                            "description": "How much optimization to perform on the circuits",
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    }
-                },
                 "execution": {
                     "description": "Execution options",
                     "type": "object",
@@ -78,8 +66,12 @@
                             "type": "number"
                         }
                     }
-                },
+                }
             }
+        },
+        "version": {
+            "description": "For SamplerV2, version should always be 2",
+            "enum": [2]
         }
     }
 }

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -14,7 +14,7 @@
                 "type": "array",
                 "minItems": 1,
                 "prefixItems": [
-                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
+                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": ["object", "string"]},
                     {"description": "A dictionary of the parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The number of shots to use in this pub", "type": "integer"}
                 ]

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -73,6 +73,10 @@
                     "description": "Default number of shots which applies to all pubs without shots",
                     "type": "integer"
                 },
+        "support_qiskit": {
+            "description": "If True, returns a qiskit-style output, meant to be parsed using the runtime result decoder, or resort to returning pure JSON results (resulting in larger objects)",
+            "type": "bool"
+        },
         "version": {
             "description": "For SamplerV2, version should always be 2",
             "enum": [2]

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -73,7 +73,7 @@
                 }
             }
         },
-        "default_shots": {
+        "shots": {
                     "description": "Default number of shots which applies to all pubs without shots",
                     "type": "integer"
                 },

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -69,7 +69,7 @@
                 }
             }
         },
-        "shots": {
+        "default_shots": {
                     "description": "Default number of shots which applies to all pubs without shots",
                     "type": "integer"
                 },

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -64,6 +64,10 @@
                         "rep_delay": {
                             "description": "The delay between a measurement and the subsequent quantum circuit",
                             "type": "number"
+                        },
+                        "meas_type": {
+                            "description": "How to process and return measurement results",
+                            "enum": ["classified", "kerneled", "avg_kerneled"]
                         }
                     }
                 }

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -18,60 +18,67 @@
                 ]
             }
         },
-        "transpilation": {
-          "description": "Transpilation settings.",
-          "type": "object",
-          "properties": {
-              "optimization_level": {
-                "description": "How much optimization to perform on the circuits",
-                "type": "integer",
-                "enum": [0, 1]
-              }
-          }
-        },
-        "execution": {
-            "description": "Execution options",
+        "options": {
             "type": "object",
+            "description": "Options for V2 Sampler",
             "properties": {
-                "shots": {
-                    "description": "Number of repetitions of each circuit, for sampling",
-                    "type": "number"
+                "default_shots": {
+                    "description": "The default number of shots to use if none are specified in the PUBs",
+                    "type": "integer"
                 },
-                "init_qubits": {
-                    "description": "Whether to reset the qubits to the ground state for each shot",
-                    "type": "boolean"
+                "dynamical_decoupling": {
+                    "description": "Suboptions for dynamical decoupling",
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "description": "Whether to enable DD as specified by the other options in this class",
+                            "type": "boolean"
+                        },
+                        "sequence_type": {
+                            "description": "Which dynamical decoupling sequence to use",
+                            "type": "string",
+                            "enum": ["XX", "XpXm", "XY4"]
+                        },
+                        "extra_slack_distribution": {
+                            "description": "Where to put extra timing delays due to rounding issues",
+                            "type": "string",
+                            "enum": ["middle", "edges"]
+                        },
+                        "scheduling_method": {
+                            "description": "Whether to schedule gates as soon as ('asap') or as late as ('alap') possible",
+                            "type": "string",
+                            "enum": ["alap", "asap"]
+                        }
+                    }
                 },
-                "samples": {
-                    "description": "The number of samples of each measurement circuit to run",
-                    "type": "number"
+                "transpilation": {
+                    "description": "Transpilation settings",
+                    "type": "object",
+                    "properties": {
+                        "optimization_level": {
+                            "description": "How much optimization to perform on the circuits",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    }
                 },
-                "shots_per_sample": {
-                    "description": "The number of shots per sample of each measurement circuit to run",
-                    "type": "number"
+                "execution": {
+                    "description": "Execution options",
+                    "type": "object",
+                    "properties": {
+                        "init_qubits": {
+                            "description": "Whether to reset the qubits to the ground state for each shot",
+                            "type": "boolean"
+                        },
+                        "rep_delay": {
+                            "description": "The delay between a measurement and the subsequent quantum circuit",
+                            "type": "number"
+                        }
+                    }
                 },
-                 "interleave_samples": {
-                    "description": "Whether to interleave samples from different measurement circuits when running or run them in order",
-                    "type": "boolean"
-                }
-            }
-        },
-        "twirling": {
-            "description": "Twirling options",
-            "type": "object",
-            "properties": {
-                "gates": {
-                    "description": "Whether to apply 2-qubit gate twirling",
-                    "type": "boolean"
-                },
-                "measure": {
-                    "description": "Whether to apply measurement twirling",
-                    "type": "boolean"
-                },
-                 "strategy": {
-                    "description": "The strategy of twirling qubits in identified layers of 2-qubit twirled gates",
-                    "type": "string",
-                    "enum": ["active", "active-circuit", "active-accum", "all"]
-                }
             }
         }
     }

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -14,7 +14,7 @@
                 "type": "array",
                 "minItems": 1,
                 "prefixItems": [
-                    {"description": "The quantum circuit", "type": "object"},
+                    {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
                     {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The numebr of shots to use in this pub", "type": "integer"}
                 ]

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -69,6 +69,10 @@
                 }
             }
         },
+        "shots": {
+                    "description": "Default number of shots which applies to all pubs without shots",
+                    "type": "integer"
+                },
         "version": {
             "description": "For SamplerV2, version should always be 2",
             "enum": [2]

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -1,30 +1,25 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/estimator_v2_schema.json",
-    "title": "EstimatorV2 input",
-    "description": "The input for an EstimatorV2 API call",
+    "id": "http://www.qiskit.org/schemas/sampler_v2_schema.json",
+    "title": "SamplerV2 input",
+    "description": "The input for an SamplerV2 API call",
     "version": "1.0.0",
     "type": "object",
     "required": ["pubs"],
     "properties": {
         "pubs": {
             "type": "array",
-            "description": "Circuits/Observbles/Parameters to run",
+            "description": "Circuits/Parameters to run",
             "items": {
                 "type": "array",
                 "prefixItems": [
                     {"description": "The quantum circuit", "type": "object"},
-                    {"description": "The observable array", "type": "object"},
                     {"description": "The parameter values", "type": "object"}
                 ]
             }
         },
-        "seed_estimator": {
-            "description": "Seed used to control sampling",
-            "type": "integer"
-        },
         "transpilation": {
-          "description": "Transpilation settings",
+          "description": "Transpilation settings.",
           "type": "object",
           "properties": {
               "optimization_level": {
@@ -33,52 +28,6 @@
                 "enum": [0, 1]
               }
           }
-        },
-        "resilience_level": {
-            "description": "How much resilience to build against errors",
-            "type": "integer",
-            "enum": [0, 1, 2]
-        },
-        "resilience": {
-            "description": "Advanced resilience options to fine tune the resilience strategy",
-            "type": "object",
-            "properties": {
-                "measure_noise_mitigation": {
-                    "description": "Whether to enable measurement error mitigation method",
-                    "type": "boolean"
-                },
-                "zne_mitigation": {
-                    "description": "Whether to turn on Zero Noise Extrapolation error mitigation method",
-                    "type": "boolean"
-                },
-                "zne_noise_factors": {
-                    "description": "A list of real valued noise factors that determine by what amount the circuits' noise is amplified",
-                    "type": "array",
-                    "items": {
-                        "type": "number"
-                    }
-                },
-                "zne_extrapolator": {
-                    "description": "A list of extrapolation strategies",
-                    "oneOf": [
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
-                            }
-                        },
-                        {
-                            "type": "string",
-                            "enum": ["exponential", "double_exponential", "linear", "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3", "polynomial_degree_4"]
-                        }
-                    ]
-                },
-                "zne_stderr_threshold": {
-                    "description": "A standard error threshold for accepting the ZNE result",
-                    "type": "number"
-                }
-            }
         },
         "execution": {
             "description": "Execution options",

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -9,14 +9,14 @@
     "properties": {
         "pubs": {
             "type": "array",
-            "description": "Circuits/Parameters to run",
+            "description": "Primitive Unit Blocs of data. Each PUB is of the form (Circuit, Parameters, Shots) where the circuit is required, parameters should be passed only for parametrized circuits, and shots is optional",
             "items": {
                 "type": "array",
                 "minItems": 1,
                 "prefixItems": [
-                    {"description": "The quantum circuit in base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
-                    {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
-                    {"description": "The numebr of shots to use in this pub", "type": "integer"}
+                    {"description": "The quantum circuit in QASM string or base64-encoded QPY format. See https://docs.quantum.ibm.com/api/qiskit/qpy for more details on QPY.", "type": "object"},
+                    {"description": "A dictionary of the parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
+                    {"description": "The number of shots to use in this pub", "type": "integer"}
                 ]
             }
         },

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -15,7 +15,7 @@
                 "minItems": 1,
                 "prefixItems": [
                     {"description": "The quantum circuit", "type": "object"},
-                    {"description": "The parameter values", "type": "object"},
+                    {"description": "The parameter values. The keys are the names of the parameters, and the values are the actual parameter values.", "type": "object"},
                     {"description": "The numebr of shots to use in this pub", "type": "integer"}
                 ]
             }

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -75,7 +75,7 @@
                 },
         "support_qiskit": {
             "description": "If True, returns a qiskit-style output, meant to be parsed using the runtime result decoder, or resort to returning pure JSON results (resulting in larger objects)",
-            "type": "bool"
+            "type": "boolean"
         },
         "version": {
             "description": "For SamplerV2, version should always be 2",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,50 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""With some utils"""
+
+import itertools
+from ddt import data, unpack
+
+class Case(dict):
+    """<no description>"""
+
+
+def generate_cases(docstring, dsc=None, name=None, **kwargs):
+    """Combines kwargs in Cartesian product and creates Case with them"""
+    ret = []
+    keys = kwargs.keys()
+    vals = kwargs.values()
+    for values in itertools.product(*vals):
+        case = Case(zip(keys, values))
+        if docstring is not None:
+            setattr(case, "__doc__", docstring.format(**case))
+        if dsc is not None:
+            setattr(case, "__doc__", dsc.format(**case))
+        if name is not None:
+            setattr(case, "__name__", name.format(**case))
+        ret.append(case)
+    return ret
+
+
+def combine(**kwargs):
+    """Decorator to create combinations and tests
+    @combine(level=[0, 1, 2, 3],
+             circuit=[a, b, c, d],
+             dsc='Test circuit {circuit.__name__} with level {level}',
+             name='{circuit.__name__}_level{level}')
+    """
+
+    def deco(func):
+        return data(*generate_cases(docstring=func.__doc__, **kwargs))(unpack(func))
+
+    return deco

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,7 @@
 import itertools
 from ddt import data, unpack
 
+
 class Case(dict):
     """<no description>"""
 

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -139,7 +139,7 @@ class TestEstimatorV2Schema(unittest.TestCase):
              enable_zne_mitigation=[True, False],
              )
     def test_zne_mitigation_options(self, noise_factors, extrapolator, enable_zne_mitigation):
-        """Testing various values of zne mitigation"""
+        """Testing various values of pec mitigation"""
         options = {
             'resilience': {
                 'zne': {
@@ -150,6 +150,26 @@ class TestEstimatorV2Schema(unittest.TestCase):
             }
         }
         self.assert_valid_options(options)
+
+    @combine(max_layers_to_learn=[0, 1, 15, -3],
+             shots_per_randomization=[0, 1, 15, -3],
+             num_randomizations=[0, 1, 15, -3],
+             layer_pair_depths=[[0, 1, 15], 15, [0, -3]]
+             )
+    def test_layer_noise_learning_options(self, max_layers_to_learn, shots_per_randomization, num_randomizations, layer_pair_depths):
+        """Testing various values of layer noise learning"""
+        options = {
+            'resilience': {
+                'layer_noise_learning': {
+                    'max_layers_to_learn': max_layers_to_learn,
+                    'shots_per_randomization': shots_per_randomization,
+                    'num_randomizations': num_randomizations,
+                    'layer_pair_depths': layer_pair_depths,
+                },
+            }
+        }
+        self.assert_valid_options(options)
+
 
     @combine(max_overhead=[0, 1, 18, None, "error"],
              noise_gain=[0, 1, 18, "auto", None, "error"],

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -53,6 +53,7 @@ class TestEstimatorV2Schema(unittest.TestCase):
             for option_name, value in options_to_check.items():
                 setattr(options, option_name, value)
             options_dict = TestEstimatorV2Schema.get_options_dict(estimator)
+            print(options_dict)
             self.assertTrue(self.validator.is_valid(options_dict))
         except AssertionError as err:
             raise err
@@ -66,6 +67,7 @@ class TestEstimatorV2Schema(unittest.TestCase):
                     dict_to_change = dict_to_change[key]
                 dict_to_change[option_name] = value
             self.assertFalse(self.validator.is_valid(options_dict))
+
     def test_basic(self):
         """Testing the bare-bones options for an estimator"""
         estimator = EstimatorV2(backend=self.backend)
@@ -142,3 +144,35 @@ class TestEstimatorV2Schema(unittest.TestCase):
             'pec_mitigation': pec_mitigation,
         }
         self.assert_valid_options(estimator, options_to_set, options_path, estimator.options.resilience)
+
+    @combine(num_randomizations=[0, 1, 2, True, "False"],
+             shots_per_randomization=[0, 1, 2, True, "False", "auto"],
+             )
+    def test_measure_noise_learning(self, num_randomizations, shots_per_randomization):
+        """Testing various values of measure noise learning"""
+        estimator = EstimatorV2(backend=self.backend)
+        options_path = ['options', 'resilience', 'measure_noise_learning']
+        options_to_set = {
+            'num_randomizations': num_randomizations,
+            'shots_per_randomization': shots_per_randomization,
+        }
+        self.assert_valid_options(estimator, options_to_set, options_path, estimator.options.resilience.measure_noise_learning)
+
+    @combine(noise_factors=[[17], [1,2], [1,4,8], [1.3, 3.2], False],
+             extrapolator=["linear", "exponential", "double_exponential",
+                               "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3",
+                               "polynomial_degree_4", "polynomial_degree_5", "polynomial_degree_6",
+                               "polynomial_degree_7", ["linear", "exponential", "polynomial_degree_3"], "false_extrapolator",
+                               13, False, [13, "linear"]
+                               ]
+             )
+    def test_zne_mitigation_options(self, noise_factors, extrapolator):
+        """Testing various values of measure noise learning"""
+        estimator = EstimatorV2(backend=self.backend)
+        options_path = ['options', 'resilience', 'zne']
+        options_to_set = {
+            'noise_factors': noise_factors,
+            'extrapolator': extrapolator,
+        }
+        self.assert_valid_options(estimator, options_to_set, options_path,
+                                  estimator.options.resilience.zne)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -151,30 +151,19 @@ class TestEstimatorV2Schema(unittest.TestCase):
         }
         self.assert_valid_options(options)
 
-# options = {"resilience": {"zne": {"noise_factors": [1, 3]}}}
-# #est_options = EstimatorOptions(**options)
-# a = TestEstimatorV2Schema()
-# a.setUp()
-# print(a.get_converted_options(options))
-# a.validator.validate(a.get_converted_options(options))
-# options = {'transpilation': {'optimization_level': 0}}
-# est_options = EstimatorOptions(**options)
-# options = {'resilience_level': 1, "resilience": {"zne": {"noise_factors": []}}}
-# res = EstimatorOptions._get_program_inputs(options)
-# print(res)
-# a = TestEstimatorV2Schema()
-# a.setUp()
-# options_dict = {'options': {'resilience': {'zne': {'noise_factors': [1.0, 4.0, 8.0], 'extrapolator': 'linear'}}}, 'version': 2, 'support_qiskit': True, 'pubs': []}
-# a.validator.validate(options_dict)
-# print(a.validator.is_valid(options_dict))
-# estimator = EstimatorV2(backend="ibmq_qasm_simulator")
-# estimator.options.resilience.zne_mitigation = True
-# estimator.options.resilience.zne.extrapolator = "linear"
-# estimator.options.resilience.zne.noise_factors = []
-# print(estimator.options._get_program_inputs(asdict(estimator.options)))
-
-#options = {"resilience": {"zne_mitigation": True, "zne": {"noise_factors": []}}}
-# options = {"resilience": {"zne": {"noise_factors": [1, 3, 5]}}}
-# est_options = EstimatorOptions(**options)
-# print(est_options)
-# print(est_options._get_program_inputs(asdict(est_options)))
+    @combine(max_overhead=[0, 1, 18, None, "error"],
+             noise_gain=[0, 1, 18, "auto", None, "error"],
+             enable_pec_mitigation=[True, False],
+             )
+    def test_pec_mitigation_options(self, max_overhead, noise_gain, enable_pec_mitigation):
+        """Testing various values of pec mitigation"""
+        options = {
+            'resilience': {
+                'pec': {
+                    'max_overhead': max_overhead,
+                    'noise_gain': noise_gain,
+                },
+                'pec_mitigation': enable_pec_mitigation
+            }
+        }
+        self.assert_valid_options(options)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -20,14 +20,16 @@ from qiskit_ibm_runtime import EstimatorOptions, SamplerOptions
 from tests import combine
 
 SCHEMAS_PATH = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        'schemas')
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "schemas"
+)
+
 
 @ddt.ddt
 class TestEstimatorV2Schema(unittest.TestCase):
     """Tests the estimator schema agrees with the format of the qiskit runtime estimator API calls"""
+
     def setUp(self) -> None:
-        with open(os.path.join(SCHEMAS_PATH, 'estimator_v2_schema.json'), 'r') as fd:
+        with open(os.path.join(SCHEMAS_PATH, "estimator_v2_schema.json"), "r") as fd:
             self.estimator_schema = json.load(fd)
         self.validator = jsonschema.Draft202012Validator(schema=self.estimator_schema)
 
@@ -36,8 +38,8 @@ class TestEstimatorV2Schema(unittest.TestCase):
         """Emulate the process in `qiskit-ibm-runtime` where the EstimatorOptions
         are converted to a filtered options dictionary"""
         converted_options = EstimatorOptions._get_program_inputs(options_dict)
-        if 'pubs' not in converted_options:
-            converted_options['pubs'] = []
+        if "pubs" not in converted_options:
+            converted_options["pubs"] = []
         return converted_options
 
     def assert_valid_options(self, options_dict):
@@ -60,47 +62,56 @@ class TestEstimatorV2Schema(unittest.TestCase):
             error_message = str(err)
 
         if estimator_options_valid:
-            self.assertTrue(options_valid, msg=f"Options should pass the JSON schema validation, but it failed with the message:\n{error_message}")
+            self.assertTrue(
+                options_valid,
+                msg=f"Options should pass the JSON schema validation, but it failed with the message:\n{error_message}",
+            )
         else:
-            self.assertFalse(options_valid, msg=f"Options passed the JSON schema validation, but it should fail since for EstimatorOptions it fails with the message:\n{error_message}")
+            self.assertFalse(
+                options_valid,
+                msg=f"Options passed the JSON schema validation, but it should fail since for EstimatorOptions it fails with the message:\n{error_message}",
+            )
 
     @ddt.data(0, 1, 2, 3, -1, 17, 3.5)
     def test_resilience_level(self, level):
         """Testing various values of the resilience level"""
-        options = {'resilience_level': level}
+        options = {"resilience_level": level}
         self.assert_valid_options(options)
 
     @ddt.data(0, 1, 3.5)
     def test_seed_estimator(self, seed):
         """Testing various values of the seed estimator"""
-        options = {'seed_estimator': seed}
+        options = {"seed_estimator": seed}
         self.assert_valid_options(options)
 
     @ddt.data(0, 1, 3.5)
     def test_default_precision(self, precision):
         """Testing various values of the default precision"""
-        options = {'default_precision': precision}
+        options = {"default_precision": precision}
         self.assert_valid_options(options)
 
     @ddt.data(0, 1, 3.5, -2)
     def test_default_shots(self, shots):
         """Testing various values of the default shots"""
-        options = {'default_shots': shots}
+        options = {"default_shots": shots}
         self.assert_valid_options(options)
 
-    @combine(enable=[True, False, 13],
-             sequence_type=["XX", "XpXm", "XY4", "ZZ", 13],
-             extra_slack_distribution=["middle", "edges", "end", 13],
-             scheduling_method=["alap", "asap", "lapsap", 13]
-             )
-    def test_dynamical_decoupling(self, enable, sequence_type, extra_slack_distribution, scheduling_method):
+    @combine(
+        enable=[True, False, 13],
+        sequence_type=["XX", "XpXm", "XY4", "ZZ", 13],
+        extra_slack_distribution=["middle", "edges", "end", 13],
+        scheduling_method=["alap", "asap", "lapsap", 13],
+    )
+    def test_dynamical_decoupling(
+        self, enable, sequence_type, extra_slack_distribution, scheduling_method
+    ):
         """Testing various values of dynamical decoupling"""
         options = {
-            'dynamical_decoupling':{
-                'enable': enable,
-                'sequence_type': sequence_type,
-                'extra_slack_distribution': extra_slack_distribution,
-                'scheduling_method': scheduling_method
+            "dynamical_decoupling": {
+                "enable": enable,
+                "sequence_type": sequence_type,
+                "extra_slack_distribution": extra_slack_distribution,
+                "scheduling_method": scheduling_method,
             }
         }
         self.assert_valid_options(options)
@@ -108,113 +119,156 @@ class TestEstimatorV2Schema(unittest.TestCase):
     @ddt.data(0, 1, 3.5, -2)
     def test_optimization_level(self, optimization_level):
         """Testing various values of the optimization level options"""
-        options = {'optimization_level': optimization_level}
+        options = {"optimization_level": optimization_level}
         self.assert_valid_options(options)
 
-    @combine(num_randomizations=[0, 1, 2, "False"],
-             shots_per_randomization=[0, 1, 2, "False", "auto"],
-             enable_measure_mitigation=[True, False],
-             )
-    def test_measure_noise_learning(self, num_randomizations, shots_per_randomization, enable_measure_mitigation):
+    @combine(
+        num_randomizations=[0, 1, 2, "False"],
+        shots_per_randomization=[0, 1, 2, "False", "auto"],
+        enable_measure_mitigation=[True, False],
+    )
+    def test_measure_noise_learning(
+        self, num_randomizations, shots_per_randomization, enable_measure_mitigation
+    ):
         """Testing various values of measure noise learning"""
         options = {
-            'resilience': {
-                'measure_noise_learning': {
-                    'num_randomizations': num_randomizations,
-                    'shots_per_randomization': shots_per_randomization,
+            "resilience": {
+                "measure_noise_learning": {
+                    "num_randomizations": num_randomizations,
+                    "shots_per_randomization": shots_per_randomization,
                 },
-                'measure_mitigation': enable_measure_mitigation
+                "measure_mitigation": enable_measure_mitigation,
             }
         }
         self.assert_valid_options(options)
 
-    @combine(noise_factors=[[17], [1,2], [1,4,8], [1.3, 3.2], False],
-             extrapolator=["linear", "exponential", "double_exponential",
-                               "polynomial_degree_1", "polynomial_degree_2", "polynomial_degree_3",
-                               "polynomial_degree_4", "polynomial_degree_5", "polynomial_degree_6",
-                               "polynomial_degree_7", ["linear", "exponential", "polynomial_degree_3"], "false_extrapolator",
-                               13, False, [13, "linear"]
-                               ],
-             enable_zne_mitigation=[True, False],
-             )
-    def test_zne_mitigation_options(self, noise_factors, extrapolator, enable_zne_mitigation):
+    @combine(
+        noise_factors=[[17], [1, 2], [1, 4, 8], [1.3, 3.2], False],
+        extrapolator=[
+            "linear",
+            "exponential",
+            "double_exponential",
+            "polynomial_degree_1",
+            "polynomial_degree_2",
+            "polynomial_degree_3",
+            "polynomial_degree_4",
+            "polynomial_degree_5",
+            "polynomial_degree_6",
+            "polynomial_degree_7",
+            ["linear", "exponential", "polynomial_degree_3"],
+            "false_extrapolator",
+            13,
+            False,
+            [13, "linear"],
+        ],
+        enable_zne_mitigation=[True, False],
+    )
+    def test_zne_mitigation_options(
+        self, noise_factors, extrapolator, enable_zne_mitigation
+    ):
         """Testing various values of pec mitigation"""
         options = {
-            'resilience': {
-                'zne': {
-                    'noise_factors': noise_factors,
-                    'extrapolator': extrapolator,
+            "resilience": {
+                "zne": {
+                    "noise_factors": noise_factors,
+                    "extrapolator": extrapolator,
                 },
-                'zne_mitigation': enable_zne_mitigation
+                "zne_mitigation": enable_zne_mitigation,
             }
         }
         self.assert_valid_options(options)
 
-    @combine(max_layers_to_learn=[0, 1, 15, -3],
-             shots_per_randomization=[0, 1, 15, -3],
-             num_randomizations=[0, 1, 15, -3],
-             layer_pair_depths=[[0, 1, 15], 15, [0, -3]]
-             )
-    def test_layer_noise_learning_options(self, max_layers_to_learn, shots_per_randomization, num_randomizations, layer_pair_depths):
+    @combine(
+        max_layers_to_learn=[0, 1, 15, -3],
+        shots_per_randomization=[0, 1, 15, -3],
+        num_randomizations=[0, 1, 15, -3],
+        layer_pair_depths=[[0, 1, 15], 15, [0, -3]],
+    )
+    def test_layer_noise_learning_options(
+        self,
+        max_layers_to_learn,
+        shots_per_randomization,
+        num_randomizations,
+        layer_pair_depths,
+    ):
         """Testing various values of layer noise learning"""
         options = {
-            'resilience': {
-                'layer_noise_learning': {
-                    'max_layers_to_learn': max_layers_to_learn,
-                    'shots_per_randomization': shots_per_randomization,
-                    'num_randomizations': num_randomizations,
-                    'layer_pair_depths': layer_pair_depths,
+            "resilience": {
+                "layer_noise_learning": {
+                    "max_layers_to_learn": max_layers_to_learn,
+                    "shots_per_randomization": shots_per_randomization,
+                    "num_randomizations": num_randomizations,
+                    "layer_pair_depths": layer_pair_depths,
                 },
             }
         }
         self.assert_valid_options(options)
 
-
-    @combine(max_overhead=[0, 1, 18, None, "error"],
-             noise_gain=[0, 1, 18, "auto", None, "error"],
-             enable_pec_mitigation=[True, False],
-             )
-    def test_pec_mitigation_options(self, max_overhead, noise_gain, enable_pec_mitigation):
+    @combine(
+        max_overhead=[0, 1, 18, None, "error"],
+        noise_gain=[0, 1, 18, "auto", None, "error"],
+        enable_pec_mitigation=[True, False],
+    )
+    def test_pec_mitigation_options(
+        self, max_overhead, noise_gain, enable_pec_mitigation
+    ):
         """Testing various values of pec mitigation"""
         options = {
-            'resilience': {
-                'pec': {
-                    'max_overhead': max_overhead,
-                    'noise_gain': noise_gain,
+            "resilience": {
+                "pec": {
+                    "max_overhead": max_overhead,
+                    "noise_gain": noise_gain,
                 },
-                'pec_mitigation': enable_pec_mitigation
+                "pec_mitigation": enable_pec_mitigation,
             }
         }
         self.assert_valid_options(options)
 
-    @combine(init_qubits=[True, False, 13],
-             rep_delay=[0, 13, 0.3, -5, 'error'],
-             )
+    @combine(
+        init_qubits=[True, False, 13],
+        rep_delay=[0, 13, 0.3, -5, "error"],
+    )
     def test_execution_options(self, init_qubits, rep_delay):
         """Testing various values of execution options"""
         options = {
-            'execution': {
-                'init_qubits': init_qubits,
-                'rep_delay': rep_delay,
+            "execution": {
+                "init_qubits": init_qubits,
+                "rep_delay": rep_delay,
             }
         }
         self.assert_valid_options(options)
 
-    @combine(enable_gates=[True, False, 13],
-             enable_measure=[True, False, 13],
-             num_randomizations=[0, 1, 18, -3, "auto", None, "error"],
-             shots_per_randomization=[0, 1, 18, -3, "auto", None, "error"],
-             strategy=["active", "active-circuit", "active-accum", "all", "auto", "error", 42],
-             )
-    def test_twirling_options(self, enable_gates, enable_measure, num_randomizations, shots_per_randomization, strategy):
+    @combine(
+        enable_gates=[True, False, 13],
+        enable_measure=[True, False, 13],
+        num_randomizations=[0, 1, 18, -3, "auto", None, "error"],
+        shots_per_randomization=[0, 1, 18, -3, "auto", None, "error"],
+        strategy=[
+            "active",
+            "active-circuit",
+            "active-accum",
+            "all",
+            "auto",
+            "error",
+            42,
+        ],
+    )
+    def test_twirling_options(
+        self,
+        enable_gates,
+        enable_measure,
+        num_randomizations,
+        shots_per_randomization,
+        strategy,
+    ):
         """Testing various values of twirling options"""
         options = {
-            'twirling': {
-                'enable_gates': enable_gates,
-                'enable_measure': enable_measure,
-                'num_randomizations': num_randomizations,
-                'shots_per_randomization': shots_per_randomization,
-                'strategy': strategy,
+            "twirling": {
+                "enable_gates": enable_gates,
+                "enable_measure": enable_measure,
+                "num_randomizations": num_randomizations,
+                "shots_per_randomization": shots_per_randomization,
+                "strategy": strategy,
             }
         }
         self.assert_valid_options(options)
@@ -223,8 +277,9 @@ class TestEstimatorV2Schema(unittest.TestCase):
 @ddt.ddt
 class TestSamplerV2Schema(unittest.TestCase):
     """Tests the sampler schema agrees with the format of the qiskit runtime sampler API calls"""
+
     def setUp(self) -> None:
-        with open(os.path.join(SCHEMAS_PATH, 'sampler_v2_schema.json'), 'r') as fd:
+        with open(os.path.join(SCHEMAS_PATH, "sampler_v2_schema.json"), "r") as fd:
             self.sampler_schema = json.load(fd)
         self.validator = jsonschema.Draft202012Validator(schema=self.sampler_schema)
 
@@ -233,8 +288,8 @@ class TestSamplerV2Schema(unittest.TestCase):
         """Emulate the process in `qiskit-ibm-runtime` where the EstimatorOptions
         are converted to a filtered options dictionary"""
         converted_options = SamplerOptions._get_program_inputs(options_dict)
-        if 'pubs' not in converted_options:
-            converted_options['pubs'] = []
+        if "pubs" not in converted_options:
+            converted_options["pubs"] = []
         return converted_options
 
     def assert_valid_options(self, options_dict):
@@ -257,42 +312,52 @@ class TestSamplerV2Schema(unittest.TestCase):
             error_message = str(err)
 
         if sampler_options_valid:
-            self.assertTrue(options_valid, msg=f"Options should pass the JSON schema validation, but it failed with the message:\n{error_message}")
+            self.assertTrue(
+                options_valid,
+                msg=f"Options should pass the JSON schema validation, but it failed with the message:\n{error_message}",
+            )
         else:
-            self.assertFalse(options_valid, msg=f"Options passed the JSON schema validation, but it should fail since for SamplerOptions it fails with the message:\n{error_message}")
+            self.assertFalse(
+                options_valid,
+                msg=f"Options passed the JSON schema validation, but it should fail since for SamplerOptions it fails with the message:\n{error_message}",
+            )
 
     @ddt.data(0, 1, 3.5, -2)
     def test_default_shots(self, shots):
         """Testing various values of the default shots"""
-        options = {'default_shots': shots}
+        options = {"default_shots": shots}
         self.assert_valid_options(options)
 
-    @combine(enable=[True, False, 13],
-             sequence_type=["XX", "XpXm", "XY4", "ZZ", 13],
-             extra_slack_distribution=["middle", "edges", "end", 13],
-             scheduling_method=["alap", "asap", "lapsap", 13]
-             )
-    def test_dynamical_decoupling(self, enable, sequence_type, extra_slack_distribution, scheduling_method):
+    @combine(
+        enable=[True, False, 13],
+        sequence_type=["XX", "XpXm", "XY4", "ZZ", 13],
+        extra_slack_distribution=["middle", "edges", "end", 13],
+        scheduling_method=["alap", "asap", "lapsap", 13],
+    )
+    def test_dynamical_decoupling(
+        self, enable, sequence_type, extra_slack_distribution, scheduling_method
+    ):
         """Testing various values of dynamical decoupling"""
         options = {
-            'dynamical_decoupling': {
-                'enable': enable,
-                'sequence_type': sequence_type,
-                'extra_slack_distribution': extra_slack_distribution,
-                'scheduling_method': scheduling_method
+            "dynamical_decoupling": {
+                "enable": enable,
+                "sequence_type": sequence_type,
+                "extra_slack_distribution": extra_slack_distribution,
+                "scheduling_method": scheduling_method,
             }
         }
         self.assert_valid_options(options)
 
-    @combine(init_qubits=[True, False, 13],
-             rep_delay=[0, 13, 0.3, -5, 'error'],
-             )
+    @combine(
+        init_qubits=[True, False, 13],
+        rep_delay=[0, 13, 0.3, -5, "error"],
+    )
     def test_execution_options(self, init_qubits, rep_delay):
         """Testing various values of execution options"""
         options = {
-            'execution': {
-                'init_qubits': init_qubits,
-                'rep_delay': rep_delay,
+            "execution": {
+                "init_qubits": init_qubits,
+                "rep_delay": rep_delay,
             }
         }
         self.assert_valid_options(options)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -16,6 +16,8 @@ import unittest
 import ddt
 import jsonschema
 
+from qiskit.circuit.library import RealAmplitudes
+from qiskit.primitives import StatevectorEstimator
 from qiskit_ibm_runtime import EstimatorOptions, SamplerOptions
 from tests import combine
 
@@ -69,7 +71,8 @@ class TestEstimatorV2Schema(unittest.TestCase):
         else:
             self.assertFalse(
                 options_valid,
-                msg=f"Options passed the JSON schema validation, but it should fail since for EstimatorOptions it fails with the message:\n{error_message}",
+                msg=f"Options passed the JSON schema validation, but it should fail since for "
+                    f"EstimatorOptions it fails with the message:\n{error_message}",
             )
 
     @ddt.data(0, 1, 2, 3, -1, 17, 3.5)
@@ -222,6 +225,7 @@ class TestEstimatorV2Schema(unittest.TestCase):
                 "pec_mitigation": enable_pec_mitigation,
             }
         }
+        print(options)
         self.assert_valid_options(options)
 
     @combine(
@@ -319,7 +323,8 @@ class TestSamplerV2Schema(unittest.TestCase):
         else:
             self.assertFalse(
                 options_valid,
-                msg=f"Options passed the JSON schema validation, but it should fail since for SamplerOptions it fails with the message:\n{error_message}",
+                msg=f"Options passed the JSON schema validation, but it should fail since for "
+                    f"SamplerOptions it fails with the message:\n{error_message}",
             )
 
     @ddt.data(0, 1, 3.5, -2)
@@ -361,3 +366,28 @@ class TestSamplerV2Schema(unittest.TestCase):
             }
         }
         self.assert_valid_options(options)
+
+
+@ddt.ddt
+class TestEstimatorResultV2Schema(unittest.TestCase):
+    """Tests the estimator result schema"""
+
+    def setUp(self) -> None:
+        with open(
+            os.path.join(SCHEMAS_PATH, "estimator_result_v2_schema.json"), "r"
+        ) as fd:
+            self.estimator_result_schema = json.load(fd)
+        self.validator = jsonschema.Draft202012Validator(
+            schema=self.estimator_result_schema
+        )
+        self.generate_backend_run_result()
+
+    def generate_backend_run_result(self):
+        self.backend = StatevectorEstimator()
+        circuit = RealAmplitudes(2)
+        self.run_result = self.backend.run(
+            [(circuit, "XX", [[1, 2, 3, 4, 5, 6, 7, 8]])]
+        ).result()
+
+    def test_run_result(self):
+        print(self.run_result)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -16,8 +16,6 @@ import unittest
 import ddt
 import jsonschema
 
-from qiskit.circuit.library import RealAmplitudes
-from qiskit.primitives import StatevectorEstimator
 from qiskit_ibm_runtime import EstimatorOptions, SamplerOptions
 from tests import combine
 

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -353,13 +353,15 @@ class TestSamplerV2Schema(unittest.TestCase):
     @combine(
         init_qubits=[True, False, 13],
         rep_delay=[0, 13, 0.3, -5, "error"],
+        meas_type=["classified", "kerneled", "avg_kerneled", "unclassified", 42],
     )
-    def test_execution_options(self, init_qubits, rep_delay):
+    def test_execution_options(self, init_qubits, rep_delay, meas_type):
         """Testing various values of execution options"""
         options = {
             "execution": {
                 "init_qubits": init_qubits,
                 "rep_delay": rep_delay,
+                "meas_type": meas_type,
             }
         }
         self.assert_valid_options(options)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -1,0 +1,65 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import json
+import os
+import unittest
+import ddt
+from dataclasses import asdict
+import jsonschema
+
+
+from qiskit_ibm_runtime import SamplerV2, EstimatorV2
+
+SCHEMAS_PATH = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'schemas')
+
+@ddt.ddt
+class TestEstimatorV2Schema(unittest.TestCase):
+    """Tests the estimator schema agrees with the format of the qiskit runtime estimator API calls"""
+    def setUp(self) -> None:
+        with open(os.path.join(SCHEMAS_PATH, 'estimator_v2_schema.json'), 'r') as fd:
+            self.estimator_schema = json.load(fd)
+        self.validator = jsonschema.Draft4Validator(schema=self.estimator_schema)
+        self.backend = "ibmq_qasm_simulator"
+
+    @staticmethod
+    def get_options_dict(estimator):
+        """Emulate the process in `qiskit-ibm-runtime` where the EstimatorOptions
+        are converted to a filtered options dictionary"""
+        options_dict = estimator.options._get_program_inputs(asdict(estimator.options))
+        if 'pubs' not in options_dict:
+            options_dict['pubs'] = []
+        return options_dict
+    def test_basic(self):
+        """Testing the bare-bones options for an estimator"""
+        estimator = EstimatorV2(backend=self.backend)
+        options = self.get_options_dict(estimator)
+        self.assertIsNone(self.validator.validate(options))
+
+    @ddt.data(0, 1, 2, 3, -1, 17, 3.5)
+    def test_resilience_level(self, level):
+        """Testing various valeus of the resilience level"""
+        estimator = EstimatorV2(backend=self.backend)
+        try:
+            estimator.options.resilience_level = level
+            options = self.get_options_dict(estimator)
+            self.assertIsNone(self.validator.validate(options))
+        except Exception:
+            # If the estimator's inner option validation failed
+            # verify our own validation fail as well
+            options = self.get_options_dict(estimator)
+            options['resilience_level'] = level
+            self.assertFalse(self.validator.is_valid(options))
+
+

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -72,7 +72,7 @@ class TestEstimatorV2Schema(unittest.TestCase):
             self.assertFalse(
                 options_valid,
                 msg=f"Options passed the JSON schema validation, but it should fail since for "
-                    f"EstimatorOptions it fails with the message:\n{error_message}",
+                f"EstimatorOptions it fails with the message:\n{error_message}",
             )
 
     @ddt.data(0, 1, 2, 3, -1, 17, 3.5)
@@ -225,7 +225,6 @@ class TestEstimatorV2Schema(unittest.TestCase):
                 "pec_mitigation": enable_pec_mitigation,
             }
         }
-        print(options)
         self.assert_valid_options(options)
 
     @combine(
@@ -324,7 +323,7 @@ class TestSamplerV2Schema(unittest.TestCase):
             self.assertFalse(
                 options_valid,
                 msg=f"Options passed the JSON schema validation, but it should fail since for "
-                    f"SamplerOptions it fails with the message:\n{error_message}",
+                f"SamplerOptions it fails with the message:\n{error_message}",
             )
 
     @ddt.data(0, 1, 3.5, -2)
@@ -366,28 +365,3 @@ class TestSamplerV2Schema(unittest.TestCase):
             }
         }
         self.assert_valid_options(options)
-
-
-@ddt.ddt
-class TestEstimatorResultV2Schema(unittest.TestCase):
-    """Tests the estimator result schema"""
-
-    def setUp(self) -> None:
-        with open(
-            os.path.join(SCHEMAS_PATH, "estimator_result_v2_schema.json"), "r"
-        ) as fd:
-            self.estimator_result_schema = json.load(fd)
-        self.validator = jsonschema.Draft202012Validator(
-            schema=self.estimator_result_schema
-        )
-        self.generate_backend_run_result()
-
-    def generate_backend_run_result(self):
-        self.backend = StatevectorEstimator()
-        circuit = RealAmplitudes(2)
-        self.run_result = self.backend.run(
-            [(circuit, "XX", [[1, 2, 3, 4, 5, 6, 7, 8]])]
-        ).result()
-
-    def test_run_result(self):
-        print(self.run_result)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -119,3 +119,26 @@ class TestEstimatorV2Schema(unittest.TestCase):
             'scheduling_method': scheduling_method
         }
         self.assert_valid_options(estimator, options_to_set, options_path, estimator.options.dynamical_decoupling)
+
+    @ddt.data(0, 1, 3.5, -2)
+    def test_transpilation(self, optimization_level):
+        """Testing various values of the transpilation options"""
+        estimator = EstimatorV2(backend=self.backend)
+        options_path = ['options', 'transpilation']
+        options_to_set = {'optimization_level': optimization_level}
+        self.assert_valid_options(estimator, options_to_set, options_path)
+
+    @combine(measure_mitigation=[True, False, 13, "False"],
+             zne_mitigation=[True, False, 13, "False"],
+             pec_mitigation=[True, False, 13, "False"],
+             )
+    def test_resilience(self, measure_mitigation, zne_mitigation, pec_mitigation):
+        """Testing various values of resilience"""
+        estimator = EstimatorV2(backend=self.backend)
+        options_path = ['options', 'resilience']
+        options_to_set = {
+            'measure_mitigation': measure_mitigation,
+            'zne_mitigation': zne_mitigation,
+            'pec_mitigation': pec_mitigation,
+        }
+        self.assert_valid_options(estimator, options_to_set, options_path, estimator.options.resilience)

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -112,8 +112,8 @@ class TestEstimatorV2Schema(unittest.TestCase):
         options = {'optimization_level': optimization_level}
         self.assert_valid_options(options)
 
-    @combine(num_randomizations=[0, 1, 2, True, "False"],
-             shots_per_randomization=[0, 1, 2, True, "False", "auto"],
+    @combine(num_randomizations=[0, 1, 2, "False"],
+             shots_per_randomization=[0, 1, 2, "False", "auto"],
              enable_measure_mitigation=[True, False],
              )
     def test_measure_noise_learning(self, num_randomizations, shots_per_randomization, enable_measure_mitigation):
@@ -150,3 +150,31 @@ class TestEstimatorV2Schema(unittest.TestCase):
             }
         }
         self.assert_valid_options(options)
+
+# options = {"resilience": {"zne": {"noise_factors": [1, 3]}}}
+# #est_options = EstimatorOptions(**options)
+# a = TestEstimatorV2Schema()
+# a.setUp()
+# print(a.get_converted_options(options))
+# a.validator.validate(a.get_converted_options(options))
+# options = {'transpilation': {'optimization_level': 0}}
+# est_options = EstimatorOptions(**options)
+# options = {'resilience_level': 1, "resilience": {"zne": {"noise_factors": []}}}
+# res = EstimatorOptions._get_program_inputs(options)
+# print(res)
+# a = TestEstimatorV2Schema()
+# a.setUp()
+# options_dict = {'options': {'resilience': {'zne': {'noise_factors': [1.0, 4.0, 8.0], 'extrapolator': 'linear'}}}, 'version': 2, 'support_qiskit': True, 'pubs': []}
+# a.validator.validate(options_dict)
+# print(a.validator.is_valid(options_dict))
+# estimator = EstimatorV2(backend="ibmq_qasm_simulator")
+# estimator.options.resilience.zne_mitigation = True
+# estimator.options.resilience.zne.extrapolator = "linear"
+# estimator.options.resilience.zne.noise_factors = []
+# print(estimator.options._get_program_inputs(asdict(estimator.options)))
+
+#options = {"resilience": {"zne_mitigation": True, "zne": {"noise_factors": []}}}
+# options = {"resilience": {"zne": {"noise_factors": [1, 3, 5]}}}
+# est_options = EstimatorOptions(**options)
+# print(est_options)
+# print(est_options._get_program_inputs(asdict(est_options)))

--- a/tests/test_primitive_schemas.py
+++ b/tests/test_primitive_schemas.py
@@ -187,3 +187,36 @@ class TestEstimatorV2Schema(unittest.TestCase):
             }
         }
         self.assert_valid_options(options)
+
+    @combine(init_qubits=[True, False, 13],
+             rep_delay=[0, 13, 0.3, -5, 'error'],
+             )
+    def test_execution_options(self, init_qubits, rep_delay):
+        """Testing various values of execution options"""
+        options = {
+            'execution': {
+                'init_qubits': init_qubits,
+                'rep_delay': rep_delay,
+            }
+        }
+        self.assert_valid_options(options)
+
+    @combine(enable_gates=[True, False, 13],
+             enable_measure=[True, False, 13],
+             num_randomizations=[0, 1, 18, -3, "auto", None, "error"],
+             shots_per_randomization=[0, 1, 18, -3, "auto", None, "error"],
+             strategy=["active", "active-circuit", "active-accum", "all", "auto", "error", 42],
+             )
+    def test_twirling_options(self, enable_gates, enable_measure, num_randomizations, shots_per_randomization, strategy):
+        """Testing various values of twirling options"""
+        options = {
+            'twirling': {
+                'enable_gates': enable_gates,
+                'enable_measure': enable_measure,
+                'num_randomizations': num_randomizations,
+                'shots_per_randomization': shots_per_randomization,
+                'strategy': strategy,
+            }
+        }
+        self.assert_valid_options(options)
+


### PR DESCRIPTION
# Summary

This PR adds schemas for input for V2 primitives (EstimatorV2/SamplerV2) which rely on `qiskit.primitives.containers` for data passing.

Addresses #[121](https://github.ibm.com/ibm-q-software/ws-primitives/issues/121)