### PR TITLE
Remove references to qiskit.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 First read the overall project contributing guidelines. These are all
 included in the qiskit documentation:
 
-https://qiskit.org/documentation/contributing_to_qiskit.html
+https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md
 
 ## Contributing to ibmq-schemas
 

--- a/schemas/backend_configuration_schema.json
+++ b/schemas/backend_configuration_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/backend_config_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/backend_configuration_schema.json",
     "description": "Qiskit device backend configuration",
     "version": "1.6.0",
     "definitions": {

--- a/schemas/backend_properties_schema.json
+++ b/schemas/backend_properties_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/backend_props_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/backend_properties_schema.json",
     "description": "OpenQuantum backend properties schema",
     "version": "1.0.0",
     "definitions": {

--- a/schemas/backend_status_schema.json
+++ b/schemas/backend_status_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/backendstatus_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/backend_status_schema.json",
     "description": "OpenQuantum backend status schema",
     "version": "1.0.0",
     "type": "object",

--- a/schemas/default_pulse_configuration_schema.json
+++ b/schemas/default_pulse_configuration_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/default_pulse_config_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/default_pulse_configuration_schema.json",
     "description": "Default OpenPulse backend configuration",
     "version": "1.0.0",
     "definitions": {

--- a/schemas/estimator_result_v2_schema.json
+++ b/schemas/estimator_result_v2_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/estimator_result_v2_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/estimator_result_v2_schema.json",
     "title": "EstimatorV2 result",
     "description": "The result for an EstimatorV2 API call",
     "version": "1.0.0",

--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/estimator_v2_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/estimator_v2_schema.json",
     "title": "EstimatorV2 input",
     "description": "The input for an EstimatorV2 API call",
     "version": "1.0.0",

--- a/schemas/ibmq_device_qobj_schema.json
+++ b/schemas/ibmq_device_qobj_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/ibm_backend_device_qobj_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/ibmq_device_qobj_schema.json",
     "description": "OpenQuantum quantum object data structure for running experiments. IBM Backend specific instructions for experimental devices. Must also validate against qobj_schema.json",
     "version": "1.0.0",
     "definitions": {        

--- a/schemas/ibmq_simulator_qobj_schema.json
+++ b/schemas/ibmq_simulator_qobj_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/ibm_backend_simulator_qobj_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/ibmq_simulator_qobj_schema.json",
     "description": "OpenQuantum quantum object data structure for running experiments. IBM Backend specific instructions for simulators. Must also validate against qobj_schema.json",
     "version": "1.0.0",
     "definitions": {        

--- a/schemas/job_status_schema.json
+++ b/schemas/job_status_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/job_status_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/job_status_schema.json",
     "description": "OpenQuantum job status schema",
     "version": "1.0.0",
     "type": "object",

--- a/schemas/qobj_schema.json
+++ b/schemas/qobj_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/qobj_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/qobj_schema.json",
     "description": "OpenQuantum quantum object data structure for running experiments",
     "version": "1.6.0",
     "definitions": {

--- a/schemas/result_schema.json
+++ b/schemas/result_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/result_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/result_schema.json",
     "title": "qobj results",
     "description": "The results of executing a qobj",
     "version": "1.0.0",

--- a/schemas/sampler_result_v2_schema.json
+++ b/schemas/sampler_result_v2_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/sampler_result_v2_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/sampler_result_v2_schema.json",
     "title": "EstimatorV2 result",
     "description": "The result for an SamplerV2 API call",
     "version": "1.0.0",

--- a/schemas/sampler_v2_schema.json
+++ b/schemas/sampler_v2_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://www.qiskit.org/schemas/sampler_v2_schema.json",
+    "id": "https://raw.githubusercontent.com/Qiskit/ibm-quantum-schemas/refs/heads/main/schemas/sampler_v2_schema.json",
     "title": "SamplerV2 input",
     "description": "The input for an SamplerV2 API call",
     "version": "1.0.0",


### PR DESCRIPTION
Removes references to qiskit.org as it no longer exists. I didn't change the deprecated schemas but can easily update them too if appropriate.
