### PR TITLE
Fix handling of exclusiveMinimum

### DIFF
--- a/schemas/estimator_v2_schema.json
+++ b/schemas/estimator_v2_schema.json
@@ -32,7 +32,8 @@
                 "default_precision": {
                     "description": "The default precision to use for any PUB that does not specify one",
                     "type": "number",
-                    "exclusiveMinimum": 0
+                    "minimum": 0,
+                    "exclusiveMinimum": true
                 },
                 "default_shots": {
                     "description": "The total number of shots to use per circuit per configuration. If set, this value overrides default_precision.",
@@ -410,7 +411,8 @@
                                     "oneOf": [
                                         {
                                             "type": "number",
-                                            "exclusiveMinimum": 0
+                                            "minimum": 0,
+                                            "exclusiveMinimum": true
                                         },
                                         {
                                             "type": "null"


### PR DESCRIPTION
Fix handling of exclusiveMinimum in estimator_v2_schema.json

> In JSON Schema Draft 4, exclusiveMinimum and exclusiveMaximum work differently. There they are boolean values, that indicate whether minimum and maximum are exclusive of the value.

https://json-schema.org/understanding-json-schema/reference/numeric