### PR TITLE
Extend Qpy model to Version 17

### DIFF
--- a/ibm_quantum_schemas/models/executor/version_0_1/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_1/models.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from ....aliases import Self
 from ...base_params_model import BaseParamsModel
 from ...pauli_lindblad_map_model import PauliLindbladMapModel
-from ...qpy_model import QpyModelV13ToV16
+from ...qpy_model import QpyModelV13ToV17
 from ...samplex_model import SamplexModelSSV1 as SamplexModel
 from ...tensor_model import F64TensorModel, TensorModel
 
@@ -61,7 +61,7 @@ class CircuitItemModel(BaseModel):
     item_type: Literal["circuit"] = "circuit"
     """The type of quantum program item."""
 
-    circuit: QpyModelV13ToV16
+    circuit: QpyModelV13ToV17
     """A QPY-encoded circuit."""
 
     circuit_arguments: F64TensorModel
@@ -101,7 +101,7 @@ class SamplexItemModel(BaseModel):
     item_type: Literal["samplex"] = "samplex"
     """The type of quantum program item."""
 
-    circuit: QpyModelV13ToV16
+    circuit: QpyModelV13ToV17
     """A QPY-encoded circuit."""
 
     samplex: SamplexModel

--- a/ibm_quantum_schemas/models/noise_learner_v3/version_0_1/models.py
+++ b/ibm_quantum_schemas/models/noise_learner_v3/version_0_1/models.py
@@ -19,7 +19,7 @@ from typing import Literal, Union
 from pydantic import BaseModel, Field, confloat
 
 from ...base_params_model import BaseParamsModel
-from ...qpy_model import QpyModelV13ToV16
+from ...qpy_model import QpyModelV13ToV17
 from ...tensor_model import F64TensorModel
 
 
@@ -28,7 +28,7 @@ class ParamsModel(BaseParamsModel):
 
     schema_version: Literal["v0.1"] = "v0.1"
 
-    instructions: QpyModelV13ToV16
+    instructions: QpyModelV13ToV17
     """The instructions targeted by the noise learner.
 
     These are embedded to a circuit prior to encoding with QPY.

--- a/ibm_quantum_schemas/models/qpy_model.py
+++ b/ibm_quantum_schemas/models/qpy_model.py
@@ -106,7 +106,7 @@ class QpyModel(BaseModel):
         return obj
 
 
-class QpyModelV13ToV16(QpyModel):
+class QpyModelV13ToV17(QpyModel):
     """QPY encoded circuits with restricted version range."""
 
-    qpy_version: int = Field(ge=13, le=16)
+    qpy_version: int = Field(ge=13, le=17)

--- a/test/models/executor/version_0_1/test_models.py
+++ b/test/models/executor/version_0_1/test_models.py
@@ -31,7 +31,7 @@ from ibm_quantum_schemas.models.executor.version_0_1.models import (
     QuantumProgramResultModel,
     SamplexItemModel,
 )
-from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
 from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1 as SamplexModel
 from ibm_quantum_schemas.models.tensor_model import F64TensorModel, TensorModel
 
@@ -50,7 +50,7 @@ def test_initialization_params_model(qpy_version, chunk_size):
     circuit.cx(0, 1)
     circuit.measure_all()
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version),
         circuit_arguments=F64TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64)),
         chunk_size=chunk_size,
     )
@@ -65,7 +65,7 @@ def test_initialization_params_model(qpy_version, chunk_size):
         circuit.measure_all()
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(template, qpy_version),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(template, qpy_version),
         samplex=SamplexModel.from_samplex(samplex),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64))
@@ -111,14 +111,14 @@ def test_chunk_size_validation():
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, 16),
         circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
     )
 
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(template, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(template, 16),
         samplex=SamplexModel.from_samplex(samplex),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))

--- a/test/models/noise_learner_v3/version_0_1/test_models.py
+++ b/test/models/noise_learner_v3/version_0_1/test_models.py
@@ -26,7 +26,7 @@ from ibm_quantum_schemas.models.noise_learner_v3.version_0_1.models import (
     TREXResultMetadataModel,
     TREXResultPostSelectionMetadataModel,
 )
-from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
 from ibm_quantum_schemas.models.tensor_model import F64TensorModel
 
 
@@ -39,7 +39,7 @@ def test_initialization_params_model(qpy_version):
     circuit.h(0)
     circuit.cx(0, 1)
     circuit.measure_all()
-    instructions = QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+    instructions = QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)
 
     params_model = ParamsModel(instructions=instructions, options=options)
 

--- a/test/models/test_qpy_model.py
+++ b/test/models/test_qpy_model.py
@@ -16,7 +16,7 @@ import pytest
 from qiskit.circuit import QuantumCircuit
 from samplomatic import ChangeBasis, InjectNoise, Twirl
 
-from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
 
 
 class TestQpyModelV13ToV16:
@@ -30,7 +30,7 @@ class TestQpyModelV13ToV16:
         circuit.cx(0, 1)
         circuit.measure_all()
 
-        encoded = QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+        encoded = QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)
         circuit_out = encoded.to_quantum_circuit()
 
         assert circuit == circuit_out
@@ -45,7 +45,7 @@ class TestQpyModelV13ToV16:
             circuit.cx(1, 2)
         circuit.measure_all()
 
-        encoded = QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+        encoded = QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)
         circuit_out = encoded.to_quantum_circuit()
 
         assert circuit == circuit_out
@@ -59,4 +59,4 @@ class TestQpyModelV13ToV16:
         circuit.measure_all()
 
         with pytest.raises(ValueError, match="QPY version"):
-            QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+            QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)


### PR DESCRIPTION
Related to #34.

This PR probably violates the repository rules, because it modifies Version 0.1. What's the proper way to provide a model for Qpy 17, which is about to be introduced in Qiskit 2.3.0 ?   Add `QpyModelV13ToV17` in addition to `QpyModelV13V16`, copy Version 0.1 to 0.2, and change the model to `QpyModelV13ToV17` in Version 0.2 ?