### PR TITLE
Add clarifications to rep_delay docstring

### DIFF
--- a/ibm_quantum_schemas/models/executor/version_0_1/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_1/models.py
@@ -41,15 +41,14 @@ class OptionsModel(BaseModel):
     """Runtime options."""
 
     init_qubits: bool = True
-    r"""Whether to reset the qubits to the ground state for each shot.
-    """
+    r"""Whether to reset the qubits to the ground state for each shot."""
 
     rep_delay: float | None = None
-    r"""The repetition delay. This is the delay between a measurement and
-    the subsequent quantum circuit. This is only supported on backends that have
-    ``backend.dynamic_reprate_enabled=True``. It must be from the
-    range supplied by ``backend.rep_delay_range``.
-    Default is given by ``backend.default_rep_delay``.
+    r"""The repetition delay. This is the delay between the end of one circuit and the start of the
+    next within a shot loop. This is only supported on backends that have
+    ``backend.dynamic_reprate_enabled=True``. It must be from the range supplied by
+    ``backend.rep_delay_range``. When this value is ``None``, the default value
+    ``backend.default_rep_delay`` is used.
     """
 
 

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -43,15 +43,14 @@ class OptionsModel(BaseModel):
     """Runtime options."""
 
     init_qubits: bool = True
-    r"""Whether to reset the qubits to the ground state for each shot.
-    """
+    r"""Whether to reset the qubits to the ground state for each shot."""
 
     rep_delay: float | None = None
-    r"""The repetition delay. This is the delay between a measurement and
-    the subsequent quantum circuit. This is only supported on backends that have
-    ``backend.dynamic_reprate_enabled=True``. It must be from the
-    range supplied by ``backend.rep_delay_range``.
-    Default is given by ``backend.default_rep_delay``.
+    r"""The repetition delay. This is the delay between the end of one circuit and the start of the
+    next within a shot loop. This is only supported on backends that have
+    ``backend.dynamic_reprate_enabled=True``. It must be from the range supplied by
+    ``backend.rep_delay_range``. When this value is ``None``, the default value
+    ``backend.default_rep_delay`` is used.
     """
 
 


### PR DESCRIPTION
Previously, it did not explicitly say what the value of ``None`` did. It was also worded in a way not entirely friendly with dynamic circuits.