### PR TITLE
Add experimental_options to 0.2 executor model

### DIFF
--- a/ibm_quantum_schemas/models/executor/version_0_1/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_1/models.py
@@ -41,15 +41,14 @@ class OptionsModel(BaseModel):
     """Runtime options."""
 
     init_qubits: bool = True
-    r"""Whether to reset the qubits to the ground state for each shot.
-    """
+    r"""Whether to reset the qubits to the ground state for each shot."""
 
     rep_delay: float | None = None
-    r"""The repetition delay. This is the delay between a measurement and
-    the subsequent quantum circuit. This is only supported on backends that have
-    ``backend.dynamic_reprate_enabled=True``. It must be from the
-    range supplied by ``backend.rep_delay_range``.
-    Default is given by ``backend.default_rep_delay``.
+    r"""The repetition delay. This is the delay between the end of one circuit and the start of the
+    next within a shot loop. This is only supported on backends that have
+    ``backend.dynamic_reprate_enabled=True``. It must be from the range supplied by
+    ``backend.rep_delay_range``. When this value is ``None``, the default value
+    ``backend.default_rep_delay`` is used.
     """
 
 

--- a/ibm_quantum_schemas/models/executor/version_0_1/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_1/models.py
@@ -44,11 +44,12 @@ class OptionsModel(BaseModel):
     r"""Whether to reset the qubits to the ground state for each shot."""
 
     rep_delay: float | None = None
-    r"""The repetition delay. This is the delay between the end of one circuit and the start of the
-    next within a shot loop. This is only supported on backends that have
-    ``backend.dynamic_reprate_enabled=True``. It must be from the range supplied by
-    ``backend.rep_delay_range``. When this value is ``None``, the default value
-    ``backend.default_rep_delay`` is used.
+    r"""The repetition delay.
+
+    This is the delay between the end of one circuit and the start of the next within a shot loop.
+    This is only supported on backends that have ``backend.dynamic_reprate_enabled=True``. It must
+    be from the range supplied by ``backend.rep_delay_range``. When this value is ``None``, the
+    default value ``backend.default_rep_delay`` is used.
     """
 
 

--- a/ibm_quantum_schemas/models/executor/version_0_2/__init__.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/__init__.py
@@ -1,0 +1,13 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Executor V0.2 Models and Validation"""

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -1,0 +1,242 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Models"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Annotated, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from ....aliases import Self
+from ...base_params_model import BaseParamsModel
+from ...pauli_lindblad_map_model import PauliLindbladMapModel
+from ...qpy_model import QpyModelV13ToV16
+from ...samplex_model import SamplexModelSSV1 as SamplexModel
+from ...tensor_model import F64TensorModel, TensorModel
+
+
+class ParamsModel(BaseParamsModel):
+    """Schema version 1 of the inner parameters."""
+
+    schema_version: Literal["v0.2"] = "v0.2"
+
+    quantum_program: QuantumProgramModel
+    """The quantum program to execution."""
+
+    options: OptionsModel
+    """Options for runtime."""
+
+
+class OptionsModel(BaseModel):
+    """Runtime options."""
+
+    init_qubits: bool = True
+    r"""Whether to reset the qubits to the ground state for each shot.
+    """
+
+    rep_delay: Optional[float] = None
+    r"""The repetition delay. This is the delay between a measurement and
+    the subsequent quantum circuit. This is only supported on backends that have
+    ``backend.dynamic_reprate_enabled=True``. It must be from the
+    range supplied by ``backend.rep_delay_range``.
+    Default is given by ``backend.default_rep_delay``.
+    """
+
+
+class CircuitItemModel(BaseModel):
+    """Execution specifications for a single quantum circuit."""
+
+    item_type: Literal["circuit"] = "circuit"
+    """The type of quantum program item."""
+
+    circuit: QpyModelV13ToV16
+    """A QPY-encoded circuit."""
+
+    circuit_arguments: F64TensorModel
+    """Arguments to the parameters of the circuit.
+
+    The last axis is over ``circuit.parameters``. Execution broadcasts over the
+    preceding axes; expect one result per element of the leading shape.
+    """
+
+    chunk_size: Union[Annotated[int, Field(ge=1)], Literal["auto"]] = "auto"
+    """The maximum number circuit arguments to bind to the circuit per shot loop.
+
+    When ``"auto"``, the number is chosen server-side with heuristics designed to optimize
+    execution speed. A quantum program must have items where either all chunk sizes are
+    integer-valued, or all chunk sizes are ``"auto"``. Integer values are only allowed inside of
+    session exection mode.
+    """
+
+    @model_validator(mode="after")
+    def cross_validate(self) -> Self:
+        """Check for mutual compatibility of types and shapes of attributes."""
+        circuit = self.circuit.to_quantum_circuit(use_cached=True)
+
+        num_parameters = self.circuit_arguments.shape[-1] if self.circuit_arguments.shape else 0
+        if num_parameters != circuit.num_parameters:
+            raise ValueError(
+                f"The size of the last axis of circuit arguments, {num_parameters}, does not "
+                f"match the number of parameters of the circuit, {circuit.num_parameters}."
+            )
+
+        return self
+
+
+class SamplexItemModel(BaseModel):
+    """Execution specifications for a single quantum circuit."""
+
+    item_type: Literal["samplex"] = "samplex"
+    """The type of quantum program item."""
+
+    circuit: QpyModelV13ToV16
+    """A QPY-encoded circuit."""
+
+    samplex: SamplexModel
+    """A JSON-encoded samplex."""
+
+    samplex_arguments: dict[str, Union[bool, int, PauliLindbladMapModel, TensorModel]]
+    """Arguments to the samplex."""
+
+    shape: list[int]
+    """The shape of this item.
+
+    This shape must extend (via broadcasting) the implicit shape of the :attr:~samplex_arguments`.
+    The non-trivial axes it introduces enumerate randomizations.
+    """
+
+    chunk_size: Union[Annotated[int, Field(ge=1)], Literal["auto"]] = "auto"
+    """The maximum number circuit arguments to bind to the circuit per shot loop.
+
+    When ``"auto"``, the number is chosen server-side with heuristics designed to optimize
+    execution speed. A quantum program must have items where either all chunk sizes are
+    integer-valued, or all chunk sizes are ``"auto"``. Integer values are only allowed inside of
+    session exection mode.
+    """
+
+    @model_validator(mode="after")
+    def cross_validate(self) -> Self:
+        """Check for mutual compatibility of types and shapes of attributes."""
+        circuit = self.circuit.to_quantum_circuit(use_cached=True)
+        samplex = self.samplex.to_samplex(use_cached=True)
+
+        if specs := samplex.outputs().get_specs("parameter_values"):
+            num_output_params = specs[0].shape[-1]
+        else:
+            num_output_params = 0
+        if (num_samplex_out := num_output_params) != circuit.num_parameters:
+            raise ValueError(
+                f"The number of samplex output parameters, {num_samplex_out}, does not match the "
+                f"number of parameters of the circuit, {circuit.num_parameters}."
+            )
+
+        return self
+
+
+class QuantumProgramModel(BaseModel):
+    """Model to store a quantum program."""
+
+    shots: int = Field(ge=1)
+    """The number of shots for each individually bound circuit."""
+
+    items: list[
+        Annotated[Union[CircuitItemModel, SamplexItemModel], Field(discriminator="item_type")]
+    ]
+    """Items of the program."""
+
+    @model_validator(mode="after")
+    def check_chunk_sizes_are_consistent(self):
+        """Check that all program items set chunk sizes consistently."""
+        chunk_sizes = {item.chunk_size for item in self.items}
+        if "auto" in chunk_sizes and len(chunk_sizes) > 1:
+            raise ValueError(
+                "Some quantum program items specified an integer-valued 'chunk_size' while others "
+                "specified 'auto', but all items must specify one or the other."
+            )
+
+        return self
+
+
+class QuantumProgramResultItemModel(BaseModel):
+    """Results for a single quantum program item."""
+
+    results: dict[str, TensorModel]
+    """A map from results to their tensor values."""
+
+    metadata: None
+    """Metadata pertaining to the execution of this particular quantum program item."""
+
+
+class ChunkPart(BaseModel):
+    """A description of the contents of a single part of an execution chunk."""
+
+    idx_item: int
+    """The index of an item in a quantum program."""
+
+    size: int
+    """The number of elements from the quantum program item that were executed.
+
+    For example, if a quantum program item has shape ``(10, 5)``, then it has a total of ``50``
+    elements, so that if this ``size`` is ``10``, it constitutes 20% of the total work for the item.
+    """
+
+
+class ChunkSpan(BaseModel):
+    """Timing information about a single chunk of execution.
+
+    .. note::
+
+        This span may include some amount of non-circuit time.
+    """
+
+    start: datetime.datetime
+    """The start time of the execution chunk in UTC."""
+
+    stop: datetime.datetime
+    """The stop time of the execution chunk in UTC."""
+
+    parts: list[ChunkPart]
+    """A description of which parts of a quantum program are contained in this chunk."""
+
+
+class MetadataModel(BaseModel):
+    """Execution metadata."""
+
+    chunk_timing: list[ChunkSpan]
+    """Timing information about all executed chunks of a quantum program."""
+
+
+class QuantumProgramResultModel(BaseModel):
+    """Result from executing a quantum program."""
+
+    schema_version: Literal["v0.2"] = "v0.2"
+    """Schema version of the result type."""
+
+    data: list[QuantumProgramResultItemModel]
+    """Resulting data for each quantum program item."""
+
+    metadata: MetadataModel
+    """Execution metadata pertaining to the job as a whole."""
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def upgrade_none_to_metadata(cls, value):
+        """Upgrade none values to empty metadata."""
+        # TODO: get rid of this in 0.2. it's only here because i want minimal changes in this PR.
+        # this is to account for an older version of v0.1, before its release, where metadata was
+        # temporarily set to None
+        if value is None:
+            value = MetadataModel(chunk_timing=[])
+        return value

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -46,7 +46,7 @@ class OptionsModel(BaseModel):
     r"""Whether to reset the qubits to the ground state for each shot.
     """
 
-    rep_delay: Optional[float] = None
+    rep_delay: float | None = None
     r"""The repetition delay. This is the delay between a measurement and
     the subsequent quantum circuit. This is only supported on backends that have
     ``backend.dynamic_reprate_enabled=True``. It must be from the
@@ -71,7 +71,7 @@ class CircuitItemModel(BaseModel):
     preceding axes; expect one result per element of the leading shape.
     """
 
-    chunk_size: Union[Annotated[int, Field(ge=1)], Literal["auto"]] = "auto"
+    chunk_size: Annotated[int, Field(ge=1)] | Literal["auto"] = "auto"
     """The maximum number circuit arguments to bind to the circuit per shot loop.
 
     When ``"auto"``, the number is chosen server-side with heuristics designed to optimize
@@ -107,7 +107,7 @@ class SamplexItemModel(BaseModel):
     samplex: SamplexModel
     """A JSON-encoded samplex."""
 
-    samplex_arguments: dict[str, Union[bool, int, PauliLindbladMapModel, TensorModel]]
+    samplex_arguments: dict[str, bool | int | PauliLindbladMapModel | TensorModel]
     """Arguments to the samplex."""
 
     shape: list[int]
@@ -117,7 +117,7 @@ class SamplexItemModel(BaseModel):
     The non-trivial axes it introduces enumerate randomizations.
     """
 
-    chunk_size: Union[Annotated[int, Field(ge=1)], Literal["auto"]] = "auto"
+    chunk_size: Annotated[int, Field(ge=1)] | Literal["auto"] = "auto"
     """The maximum number circuit arguments to bind to the circuit per shot loop.
 
     When ``"auto"``, the number is chosen server-side with heuristics designed to optimize
@@ -151,9 +151,7 @@ class QuantumProgramModel(BaseModel):
     shots: int = Field(ge=1)
     """The number of shots for each individually bound circuit."""
 
-    items: list[
-        Annotated[Union[CircuitItemModel, SamplexItemModel], Field(discriminator="item_type")]
-    ]
+    items: list[Annotated[CircuitItemModel | SamplexItemModel, Field(discriminator="item_type")]]
     """Items of the program."""
 
     @model_validator(mode="after")

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 import datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from ....aliases import Self
 from ...base_params_model import BaseParamsModel
 from ...pauli_lindblad_map_model import PauliLindbladMapModel
-from ...qpy_model import QpyModelV13ToV16
-from ...samplex_model import SamplexModelSSV1 as SamplexModel
+from ...qpy_model import QpyModelV13ToV17
+from ...samplex_model import SamplexModelSSV1ToSSV2 as SamplexModel
 from ...tensor_model import F64TensorModel, TensorModel
 
 
@@ -60,7 +60,7 @@ class CircuitItemModel(BaseModel):
     item_type: Literal["circuit"] = "circuit"
     """The type of quantum program item."""
 
-    circuit: QpyModelV13ToV16
+    circuit: QpyModelV13ToV17
     """A QPY-encoded circuit."""
 
     circuit_arguments: F64TensorModel
@@ -100,7 +100,7 @@ class SamplexItemModel(BaseModel):
     item_type: Literal["samplex"] = "samplex"
     """The type of quantum program item."""
 
-    circuit: QpyModelV13ToV16
+    circuit: QpyModelV13ToV17
     """A QPY-encoded circuit."""
 
     samplex: SamplexModel
@@ -226,14 +226,3 @@ class QuantumProgramResultModel(BaseModel):
 
     metadata: MetadataModel
     """Execution metadata pertaining to the job as a whole."""
-
-    @field_validator("metadata", mode="before")
-    @classmethod
-    def upgrade_none_to_metadata(cls, value):
-        """Upgrade none values to empty metadata."""
-        # TODO: get rid of this in 0.2. it's only here because i want minimal changes in this PR.
-        # this is to account for an older version of v0.1, before its release, where metadata was
-        # temporarily set to None
-        if value is None:
-            value = MetadataModel(chunk_timing=[])
-        return value

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, JsonValue, model_validator
 
 from ....aliases import Self
 from ...base_params_model import BaseParamsModel
@@ -66,6 +66,12 @@ class OptionsModel(BaseModel):
 
     Setting this value to true will cause corresponding metadata of every program item to be
     populated in the returned data.
+    """
+
+    experimental: dict[str, JsonValue] = Field(default_factory=dict)
+    """Experimental options.
+
+    These options are not guaranteed to be stable and may change or be removed without notice.
     """
 
 

--- a/ibm_quantum_schemas/models/executor/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2/models.py
@@ -43,15 +43,14 @@ class OptionsModel(BaseModel):
     """Runtime options."""
 
     init_qubits: bool = True
-    r"""Whether to reset the qubits to the ground state for each shot.
-    """
+    r"""Whether to reset the qubits to the ground state for each shot."""
 
     rep_delay: float | None = None
-    r"""The repetition delay. This is the delay between a measurement and
-    the subsequent quantum circuit. This is only supported on backends that have
-    ``backend.dynamic_reprate_enabled=True``. It must be from the
-    range supplied by ``backend.rep_delay_range``.
-    Default is given by ``backend.default_rep_delay``.
+    r"""The repetition delay. This is the delay between the end of one circuit and the start of the
+    next within a shot loop. This is only supported on backends that have
+    ``backend.dynamic_reprate_enabled=True``. It must be from the range supplied by
+    ``backend.rep_delay_range``. When this value is ``None``, the default value
+    ``backend.default_rep_delay`` is used.
     """
 
 

--- a/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/__init__.py
+++ b/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/__init__.py
@@ -1,0 +1,13 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""NoiseLearnerV3 V0.2 Models and Validation"""

--- a/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
@@ -19,7 +19,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, confloat
 
 from ...base_params_model import BaseParamsModel
-from ...qpy_model import QpyModelV13ToV16
+from ...qpy_model import QpyModelV13ToV17
 from ...tensor_model import F64TensorModel
 
 
@@ -28,7 +28,7 @@ class ParamsModel(BaseParamsModel):
 
     schema_version: Literal["v0.2"] = "v0.2"
 
-    instructions: QpyModelV13ToV16
+    instructions: QpyModelV13ToV17
     """The instructions targeted by the noise learner.
 
     These are embedded to a circuit prior to encoding with QPY.

--- a/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Literal
 
 from pydantic import BaseModel, Field, confloat
 
@@ -119,7 +119,7 @@ class NoiseLearnerV3ResultModel(BaseModel):
     rates_std: F64TensorModel
     """The standard deviation associated to the rates of the generators."""
 
-    metadata: Union[TREXResultMetadataModel, LinbdbladResultMetadataModel] = Field(
+    metadata: TREXResultMetadataModel | LinbdbladResultMetadataModel = Field(
         discriminator="learning_protocol"
     )
     """Execution metadata pertaining to a single result."""

--- a/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
+++ b/ibm_quantum_schemas/models/noise_learner_v3/version_0_2/models.py
@@ -1,0 +1,135 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Models"""
+
+from __future__ import annotations
+
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field, confloat
+
+from ...base_params_model import BaseParamsModel
+from ...qpy_model import QpyModelV13ToV16
+from ...tensor_model import F64TensorModel
+
+
+class ParamsModel(BaseParamsModel):
+    """Schema version 1 of the inner parameters."""
+
+    schema_version: Literal["v0.2"] = "v0.2"
+
+    instructions: QpyModelV13ToV16
+    """The instructions targeted by the noise learner.
+
+    These are embedded to a circuit prior to encoding with QPY.
+    """
+
+    options: OptionsModel
+    """Options for runtime."""
+
+
+class PostSelectionOptionsModel(BaseModel):
+    """Runtime options for post selection."""
+
+    enable: bool = False
+    """Whether to enable Post Selection when performing learning experiments.
+
+    If ``False``, all the other Post Selection options are ignored.
+    """
+
+    x_pulse_type: Literal["xslow", "rx"] = "xslow"
+    """The type of the X-pulse used for the post selection measurements."""
+
+    strategy: Literal["node", "edge"] = "node"
+    """The strategy used to decide if a shot should be kept or discarded."""
+
+
+class OptionsModel(BaseModel):
+    """Runtime options with all fields set."""
+
+    shots_per_randomization: int = 128
+    """The total number of shots to use per randomized learning circuit."""
+
+    num_randomizations: int = 32
+    """The number of random circuits to use per learning circuit configuration."""
+
+    layer_pair_depths: list[int] = [0, 1, 2, 4, 16, 32]
+    """The circuit depths (measured in number of pairs) to use in Pauli Lindblad experiments."""
+
+    post_selection: PostSelectionOptionsModel = Field(default_factory=PostSelectionOptionsModel)
+    """Options for post selecting the results of noise learning circuits."""
+
+
+class TREXResultPostSelectionMetadataModel(BaseModel):
+    """The post selection metadata of a single TREX result of a noise learner v3 job."""
+
+    fraction_kept: float = Field(ge=0, le=1)
+    """The fraction of shots kept."""
+
+
+class TREXResultMetadataModel(BaseModel):
+    """The metadata of a single TREX result of a noise learner v3 job."""
+
+    learning_protocol: Literal["trex"] = "trex"
+    """The learning protocol used to obtain this result."""
+
+    post_selection: TREXResultPostSelectionMetadataModel
+    """The metadata relative to post selection."""
+
+
+class LinbdbladResultPostSelectionMetadataModel(BaseModel):
+    """The post selection metadata of a single Linbdblad result of a noise learner v3 job."""
+
+    fraction_kept: dict[int, confloat(ge=0, le=1)]  # type: ignore
+    """The fraction of shots kept for each layer pair depth."""
+
+
+class LinbdbladResultMetadataModel(BaseModel):
+    """The metadata of a single Lindblad result of a noise learner v3 job."""
+
+    learning_protocol: Literal["lindblad"] = "lindblad"
+    """The learning protocol used to obtain this result."""
+
+    post_selection: LinbdbladResultPostSelectionMetadataModel
+    """The metadata relative to post selection."""
+
+
+class NoiseLearnerV3ResultModel(BaseModel):
+    """Results for a single noise learner V3 item."""
+
+    generators_sparse: list[list[tuple[str, list[int]]]]
+    """A representation of the generators in sparse format."""
+
+    num_qubits: int
+    """The number of qubits that the generators act on."""
+
+    rates: F64TensorModel
+    """The rates of the individual generators."""
+
+    rates_std: F64TensorModel
+    """The standard deviation associated to the rates of the generators."""
+
+    metadata: Union[TREXResultMetadataModel, LinbdbladResultMetadataModel] = Field(
+        discriminator="learning_protocol"
+    )
+    """Execution metadata pertaining to a single result."""
+
+
+class NoiseLearnerV3ResultsModel(BaseModel):
+    """Result from executing a noise learner v3 job."""
+
+    schema_version: Literal["v0.2"] = "v0.2"
+    """Schema version of the result type."""
+
+    data: list[NoiseLearnerV3ResultModel]
+    """Resulting data for each item."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "pydantic>=2.1,<3.0.0",
+    "pydantic>=2.5,<3.0.0",
     "qiskit>=2.2.0,<3.0.0",
     "samplomatic>=0.12.0",
 ]

--- a/test/models/executor/version_0_2/__init__.py
+++ b/test/models/executor/version_0_2/__init__.py
@@ -1,0 +1,13 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for 0.2 models."""

--- a/test/models/executor/version_0_2/test_models.py
+++ b/test/models/executor/version_0_2/test_models.py
@@ -1,0 +1,131 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for 0.2 models."""
+
+import datetime
+
+import numpy as np
+import pytest
+from qiskit.circuit import Parameter, QuantumCircuit
+from samplomatic import Twirl, build
+
+from ibm_quantum_schemas.models.executor.version_0_2.models import (
+    ChunkPart,
+    ChunkSpan,
+    CircuitItemModel,
+    MetadataModel,
+    OptionsModel,
+    ParamsModel,
+    QuantumProgramModel,
+    QuantumProgramResultItemModel,
+    QuantumProgramResultModel,
+    SamplexItemModel,
+)
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1 as SamplexModel
+from ibm_quantum_schemas.models.tensor_model import F64TensorModel, TensorModel
+
+
+@pytest.mark.parametrize(
+    "qpy_version,chunk_size", [(13, 2), (14, 2), (15, 2), (16, 2), (16, "auto")]
+)
+def test_initialization_params_model(qpy_version, chunk_size):
+    """Test initialization for ``ParamsModel`` and related models."""
+    options = OptionsModel()
+
+    circuit = QuantumCircuit(3)
+    circuit.rx(Parameter("theta"), 0)
+    circuit.rz(Parameter("phi"), 0)
+    circuit.rx(Parameter("lam"), 0)
+    circuit.cx(0, 1)
+    circuit.measure_all()
+    circuit_item = CircuitItemModel(
+        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version),
+        circuit_arguments=F64TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64)),
+        chunk_size=chunk_size,
+    )
+
+    circuit = QuantumCircuit(3)
+    with circuit.box([Twirl()]):
+        circuit.rx(Parameter("theta"), 0)
+        circuit.rz(Parameter("phi"), 0)
+        circuit.rx(Parameter("lam"), 0)
+        circuit.cx(0, 1)
+    with circuit.box([Twirl()]):
+        circuit.measure_all()
+    template, samplex = build(circuit)
+    samplex_item = SamplexItemModel(
+        circuit=QpyModelV13ToV16.from_quantum_circuit(template, qpy_version),
+        samplex=SamplexModel.from_samplex(samplex, ssv=1),
+        samplex_arguments={
+            "parameter_values": TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64))
+        },
+        shape=(200, 300),
+        chunk_size=chunk_size,
+    )
+
+    quantum_program = QuantumProgramModel(shots=1000, items=[circuit_item, samplex_item])
+    params_model = ParamsModel(quantum_program=quantum_program, options=options)
+
+    assert params_model.schema_version == "v0.2"
+    assert params_model.quantum_program == quantum_program
+    assert params_model.options == options
+
+
+def test_initialization_results_model():
+    """Test initialization for ``QuantumProgramResultModel`` and related models."""
+    result_item = QuantumProgramResultItemModel(
+        results={
+            "alpha": TensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
+            "beta": TensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
+        },
+        metadata=None,
+    )
+    now = datetime.datetime.now()
+    spans = [
+        ChunkSpan(
+            start=now,
+            stop=now + datetime.timedelta(seconds=5.1),
+            parts=[ChunkPart(idx_item=0, size=5)],
+        )
+    ]
+    metadata = MetadataModel(chunk_timing=spans)
+    results = QuantumProgramResultModel(data=[result_item], metadata=metadata)
+
+    assert results.schema_version == "v0.2"
+    assert results.data == [result_item]
+    assert results.metadata == metadata
+
+
+def test_chunk_size_validation():
+    """Test initialization for ``ParamsModel`` and related models."""
+    circuit = QuantumCircuit(3)
+    circuit_item = CircuitItemModel(
+        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, 16),
+        circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
+        chunk_size=2,
+    )
+
+    template, samplex = build(circuit)
+    samplex_item = SamplexItemModel(
+        circuit=QpyModelV13ToV16.from_quantum_circuit(template, 16),
+        samplex=SamplexModel.from_samplex(samplex, ssv=1),
+        samplex_arguments={
+            "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))
+        },
+        shape=(),
+        chunk_size="auto",
+    )
+
+    with pytest.raises(ValueError, match="all items must specify one or the other"):
+        QuantumProgramModel(shots=1000, items=[circuit_item, samplex_item])

--- a/test/models/executor/version_0_2/test_models.py
+++ b/test/models/executor/version_0_2/test_models.py
@@ -43,7 +43,7 @@ from ibm_quantum_schemas.models.tensor_model import F64TensorModel, TensorModel
 @pytest.mark.skip_if_samplomatic_too_old_for_ssv
 @pytest.mark.parametrize(
     "qpy_version,ssv,chunk_size",
-    [(13, 21, 2), (14, 1, 2), (15, 2, 2), (16, 1, 2), (17, 2, 2), (16, 1, "auto"), (16, 2, "auto")],
+    [(13, 2, 2), (14, 1, 2), (15, 2, 2), (16, 1, 2), (17, 2, 2), (16, 1, "auto"), (16, 2, "auto")],
 )
 def test_initialization_params_model(qpy_version, ssv, chunk_size):
     """Test initialization for ``ParamsModel`` and related models."""

--- a/test/models/executor/version_0_2/test_models.py
+++ b/test/models/executor/version_0_2/test_models.py
@@ -23,6 +23,7 @@ from ibm_quantum_schemas.models.executor.version_0_2.models import (
     ChunkPart,
     ChunkSpan,
     CircuitItemModel,
+    ItemMetadataModel,
     MetadataModel,
     OptionsModel,
     ParamsModel,
@@ -30,6 +31,8 @@ from ibm_quantum_schemas.models.executor.version_0_2.models import (
     QuantumProgramResultItemModel,
     QuantumProgramResultModel,
     SamplexItemModel,
+    SchedulerTimingModel,
+    StretchValueModel,
 )
 from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
 from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1ToSSV2 as SamplexModel
@@ -92,7 +95,7 @@ def test_initialization_results_model():
             "alpha": TensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
             "beta": TensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
         },
-        metadata=None,
+        metadata=ItemMetadataModel(),
     )
     now = datetime.datetime.now()
     spans = [
@@ -132,3 +135,60 @@ def test_chunk_size_validation():
 
     with pytest.raises(ValueError, match="all items must specify one or the other"):
         QuantumProgramModel(shots=1000, items=[circuit_item, samplex_item])
+
+
+def test_options_model_scheduler_timing_and_stretch_values():
+    """Test OptionsModel with scheduler_timing and stretch_values fields."""
+    options = OptionsModel()
+    assert not options.scheduler_timing
+    assert not options.stretch_values
+
+    options = OptionsModel(scheduler_timing=True)
+    assert options.scheduler_timing
+    assert not options.stretch_values
+
+    options = OptionsModel(stretch_values=True)
+    assert not options.scheduler_timing
+    assert options.stretch_values
+
+    options = OptionsModel(scheduler_timing=True, stretch_values=True)
+    assert options.scheduler_timing
+    assert options.stretch_values
+
+
+def test_scheduler_timing_model():
+    """Test SchedulerTimingModel initialization and fields."""
+    timing = SchedulerTimingModel(timing="0,100,200,300", circuit_duration=400)
+    assert timing.timing == "0,100,200,300"
+    assert timing.circuit_duration == 400
+
+
+def test_stretch_value_model():
+    """Test StretchValueModel initialization and fields."""
+    stretch = StretchValueModel(
+        name="delay_stretch",
+        value=100,
+        remainder=4,
+        expanded_values=[(0, 100), (200, 104), (500, 100)],
+    )
+    assert stretch.name == "delay_stretch"
+    assert stretch.value == 100
+    assert stretch.remainder == 4
+    assert stretch.expanded_values == [(0, 100), (200, 104), (500, 100)]
+
+
+def test_result_item_with_metadata():
+    """Test QuantumProgramResultItemModel with populated metadata."""
+    scheduler_timing = SchedulerTimingModel(timing="0,100,200", circuit_duration=300)
+    stretch = StretchValueModel(name="stretch_1", value=80, remainder=0, expanded_values=[(50, 80)])
+    item_metadata = ItemMetadataModel(scheduler_timing=scheduler_timing, stretch_values=[stretch])
+
+    result_item = QuantumProgramResultItemModel(
+        results={
+            "counts": TensorModel.from_numpy(np.array([100, 200], dtype=np.float64)),
+        },
+        metadata=item_metadata,
+    )
+
+    assert result_item.metadata.scheduler_timing == scheduler_timing
+    assert result_item.metadata.stretch_values == [stretch]

--- a/test/models/executor/version_0_2/test_models.py
+++ b/test/models/executor/version_0_2/test_models.py
@@ -156,6 +156,23 @@ def test_options_model_scheduler_timing_and_stretch_values():
     assert options.stretch_values
 
 
+def test_options_model_experimental():
+    """Test OptionsModel experimental field with nested JSON values."""
+    options = OptionsModel()
+    assert options.experimental == {}
+
+    nested_data = {
+        "feature_flag": True,
+        "threshold": 0.5,
+        "config": {
+            "nested_list": [1, 2, {"deep": "value"}],
+            "nested_bool": False,
+        },
+    }
+    options = OptionsModel(experimental=nested_data)
+    assert options.experimental == nested_data
+
+
 def test_scheduler_timing_model():
     """Test SchedulerTimingModel initialization and fields."""
     timing = SchedulerTimingModel(timing="0,100,200,300", circuit_duration=400)

--- a/test/models/executor/version_0_2/test_models.py
+++ b/test/models/executor/version_0_2/test_models.py
@@ -31,15 +31,18 @@ from ibm_quantum_schemas.models.executor.version_0_2.models import (
     QuantumProgramResultModel,
     SamplexItemModel,
 )
-from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
-from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1 as SamplexModel
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
+from ibm_quantum_schemas.models.samplex_model import SamplexModelSSV1ToSSV2 as SamplexModel
 from ibm_quantum_schemas.models.tensor_model import F64TensorModel, TensorModel
 
 
+@pytest.mark.skip_if_qiskit_too_old_for_qpy
+@pytest.mark.skip_if_samplomatic_too_old_for_ssv
 @pytest.mark.parametrize(
-    "qpy_version,chunk_size", [(13, 2), (14, 2), (15, 2), (16, 2), (16, "auto")]
+    "qpy_version,ssv,chunk_size",
+    [(13, 21, 2), (14, 1, 2), (15, 2, 2), (16, 1, 2), (17, 2, 2), (16, 1, "auto"), (16, 2, "auto")],
 )
-def test_initialization_params_model(qpy_version, chunk_size):
+def test_initialization_params_model(qpy_version, ssv, chunk_size):
     """Test initialization for ``ParamsModel`` and related models."""
     options = OptionsModel()
 
@@ -50,7 +53,7 @@ def test_initialization_params_model(qpy_version, chunk_size):
     circuit.cx(0, 1)
     circuit.measure_all()
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version),
         circuit_arguments=F64TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64)),
         chunk_size=chunk_size,
     )
@@ -65,8 +68,8 @@ def test_initialization_params_model(qpy_version, chunk_size):
         circuit.measure_all()
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(template, qpy_version),
-        samplex=SamplexModel.from_samplex(samplex, ssv=1),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(template, qpy_version),
+        samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64))
         },
@@ -111,14 +114,14 @@ def test_chunk_size_validation():
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, 16),
         circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
     )
 
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(template, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(template, 16),
         samplex=SamplexModel.from_samplex(samplex, ssv=1),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))

--- a/test/models/noise_learner_v3/version_0_2/__init__.py
+++ b/test/models/noise_learner_v3/version_0_2/__init__.py
@@ -1,0 +1,13 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for 0.2 models."""

--- a/test/models/noise_learner_v3/version_0_2/test_models.py
+++ b/test/models/noise_learner_v3/version_0_2/test_models.py
@@ -1,0 +1,76 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for 0.2 models."""
+
+import numpy as np
+import pytest
+from qiskit.circuit import QuantumCircuit
+
+from ibm_quantum_schemas.models.noise_learner_v3.version_0_2.models import (
+    LinbdbladResultMetadataModel,
+    LinbdbladResultPostSelectionMetadataModel,
+    NoiseLearnerV3ResultModel,
+    NoiseLearnerV3ResultsModel,
+    OptionsModel,
+    ParamsModel,
+    TREXResultMetadataModel,
+    TREXResultPostSelectionMetadataModel,
+)
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.tensor_model import F64TensorModel
+
+
+@pytest.mark.parametrize("qpy_version", [13, 14, 15, 16])
+def test_initialization_params_model(qpy_version):
+    """Test initialization for ``ParamsModel`` and related models."""
+    options = OptionsModel()
+
+    circuit = QuantumCircuit(3)
+    circuit.h(0)
+    circuit.cx(0, 1)
+    circuit.measure_all()
+    instructions = QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+
+    params_model = ParamsModel(instructions=instructions, options=options)
+
+    assert params_model.schema_version == "v0.2"
+    assert params_model.instructions == instructions
+    assert params_model.options == options
+
+
+def test_initialization_results_model():
+    """Test initialization for ``NoiseLearnerV3ResultsModel`` and related models."""
+    lindblad_datum = NoiseLearnerV3ResultModel(
+        generators_sparse=[[("XI", [0, 1]), ("XX", [1, 2])]],
+        num_qubits=2,
+        rates=F64TensorModel.from_numpy(np.array(range(2), dtype=np.float64)),
+        rates_std=F64TensorModel.from_numpy(np.zeros((2,), dtype=np.float64)),
+        metadata=LinbdbladResultMetadataModel(
+            post_selection=LinbdbladResultPostSelectionMetadataModel(fraction_kept={0: 0.8, 2: 0.7})
+        ),
+    )
+
+    trex_datum = NoiseLearnerV3ResultModel(
+        generators_sparse=[[("X", [0]), ("X", [1])]],
+        num_qubits=2,
+        rates=F64TensorModel.from_numpy(np.array(range(2), dtype=np.float64)),
+        rates_std=F64TensorModel.from_numpy(np.zeros((2,), dtype=np.float64)),
+        metadata=TREXResultMetadataModel(
+            post_selection=TREXResultPostSelectionMetadataModel(fraction_kept=0.9)
+        ),
+    )
+
+    results = NoiseLearnerV3ResultsModel(data=[lindblad_datum, trex_datum])
+
+    assert results.schema_version == "v0.2"
+    assert results.data == [lindblad_datum, trex_datum]

--- a/test/models/noise_learner_v3/version_0_2/test_models.py
+++ b/test/models/noise_learner_v3/version_0_2/test_models.py
@@ -26,11 +26,12 @@ from ibm_quantum_schemas.models.noise_learner_v3.version_0_2.models import (
     TREXResultMetadataModel,
     TREXResultPostSelectionMetadataModel,
 )
-from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV16
+from ibm_quantum_schemas.models.qpy_model import QpyModelV13ToV17
 from ibm_quantum_schemas.models.tensor_model import F64TensorModel
 
 
-@pytest.mark.parametrize("qpy_version", [13, 14, 15, 16])
+@pytest.mark.skip_if_qiskit_too_old_for_qpy
+@pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
 def test_initialization_params_model(qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     options = OptionsModel()
@@ -39,7 +40,7 @@ def test_initialization_params_model(qpy_version):
     circuit.h(0)
     circuit.cx(0, 1)
     circuit.measure_all()
-    instructions = QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version)
+    instructions = QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)
 
     params_model = ParamsModel(instructions=instructions, options=options)
 


### PR DESCRIPTION
Closes #54. Found out that Pydantic 2.5 has a nice JsonValue type, which is exactly what we want here. I had sort of been dreading getting the recursive typing correct and working for pyright+pydantic+etc.