### PR TITLE
Add documentation about releases and versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ pip install -e ".[dev]"
 
 ### Testing
 
-Testing is done with `pytest` and tests are located in the `test` folder. To run them, execute
+Testing is done with `pytest` and tests are located in the `test` folder. To run them, execute:
 
 ```bash
 pytest
@@ -34,7 +34,8 @@ pytest
 ruff check .
 ```
 
-More conveniently, set up ruff in your IDE to run-on-save and/or set up the [Pre-commit Hooks](#pre-commit-hooks).
+More conveniently, set up ruff in your IDE to run-on-save and/or set up the
+[pre-commit Hooks](#pre-commit-hooks).
 
 ### Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Please note:
 * when a new version is in development, it will contain a `_dev` suffix for signalling it
   (`.version_<x_y>_dev`). Such version are not considered stable yet.
 * other (non `_dev`) versions included in releases of this package are considered stable, albeit
-  not all of them might be supported by the IBM Quantum platform at a given time. Please refer to
-  the [Qiskit Runtime REST API] for the specific versions supported.
+  not all of them might be supported by the IBM Quantum platform at a given time. In particular,
+  the programs included in the initial release of this library (`executor` and `noise_learner_v3`)
+  are considered beta and not yet supported.
+* please refer to the [Qiskit Runtime REST API] for the programs and their versions supported by
+  the IBM Quantum platform.
 
 ## History
 


### PR DESCRIPTION
Related to #59 

Update the contribution guidelines in order to include the release and versioning policy (oriented to developers), as well as updating the README with some distilled version (oriented to consumers).

In the process, revised a bit the existing contribution guidelines to better reflect the current approach.