### PR TITLE
Add experimental_options to 0.2 executor model

### DIFF
--- a/ibm_quantum_schemas/models/executor/version_0_2_dev/models.py
+++ b/ibm_quantum_schemas/models/executor/version_0_2_dev/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, JsonValue, model_validator
 from typing_extensions import TypeAliasType
 
 from ....aliases import Self
@@ -77,6 +77,12 @@ class OptionsModel(BaseModel):
 
     Setting this value to true will cause corresponding metadata of every program item to be
     populated in the returned data.
+    """
+
+    experimental: dict[str, JsonValue] = Field(default_factory=dict)
+    """Experimental options.
+
+    These options are not guaranteed to be stable and may change or be removed without notice.
     """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "pydantic>=2.1,<3.0.0",
+    "pydantic>=2.5,<3.0.0",
     "qiskit>=2.2.0,<3.0.0",
     "samplomatic>=0.12.0",
 ]

--- a/test/models/executor/version_0_2_dev/test_models.py
+++ b/test/models/executor/version_0_2_dev/test_models.py
@@ -174,6 +174,23 @@ def test_options_model_scheduler_timing_and_stretch_values():
     assert options.stretch_values
 
 
+def test_options_model_experimental():
+    """Test OptionsModel experimental field with nested JSON values."""
+    options = OptionsModel()
+    assert options.experimental == {}
+
+    nested_data = {
+        "feature_flag": True,
+        "threshold": 0.5,
+        "config": {
+            "nested_list": [1, 2, {"deep": "value"}],
+            "nested_bool": False,
+        },
+    }
+    options = OptionsModel(experimental=nested_data)
+    assert options.experimental == nested_data
+
+
 def test_scheduler_timing_model():
     """Test SchedulerTimingModel initialization and fields."""
     timing = SchedulerTimingModel(timing="0,100,200,300", circuit_duration=400)


### PR DESCRIPTION
Closes https://github.com/Qiskit/ibm-quantum-schemas/issues/54. Found out that Pydantic 2.5 has a nice JsonValue/JsonDict types, which is exactly what we want here.