### PR TITLE
Prepare release 0.3.20260226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.3.20260226](https://github.com/Qiskit/ibm-quantum-schemas/tree/0.3.20260226) - 2026-02-26
 
-No significant changes.
+- The module docstrings for the released programs can now be consumed by `qiskit-ibm-runtime`
+  documentation.
 
 
 ## [0.2.20260209](https://github.com/Qiskit/ibm-quantum-schemas/tree/0.2.20260209) - 2026-02-09

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ language = "en"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.2.20260209"
+release = "0.3.20260226"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Update changelog and bits for preparing `0.3.20260226` release.