### PR TITLE
Fix section in changelog for 0.3.20260226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## [0.3.20260226](https://github.com/Qiskit/ibm-quantum-schemas/tree/0.3.20260226) - 2026-02-26
 
+### Changed
+
 - The module docstrings for the released programs can now be consumed by `qiskit-ibm-runtime`
   documentation.
-
 
 ## [0.2.20260209](https://github.com/Qiskit/ibm-quantum-schemas/tree/0.2.20260209) - 2026-02-09
 


### PR DESCRIPTION
Prior to release, fix a missing section for the changelog entry for `0.3.20260226` - which should have been included in #92 .