### PR TITLE
NoiseLearnerV2: `schema-version` also not allowed in input model

### DIFF
--- a/ibm_quantum_schemas/models/noise_learner_v2/version_0_1_dev/models.py
+++ b/ibm_quantum_schemas/models/noise_learner_v2/version_0_1_dev/models.py
@@ -35,9 +35,6 @@ class ParamsModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: str = "v0.1"
-    """Schema version of the program input."""
-
     version: Literal[2] | None = 2
     """Version of the program."""
 


### PR DESCRIPTION
see title. This piece was missing in #96