### PR TITLE
Estimator + NoiseLearnerV2: Deprecate basis_gates simulator options field

### DIFF
--- a/ibm_quantum_schemas/models/estimator/version_0_1_dev/simulator_options_model.py
+++ b/ibm_quantum_schemas/models/estimator/version_0_1_dev/simulator_options_model.py
@@ -60,9 +60,7 @@ class SimulatorOptionsModel(BaseModel):
     """
 
     basis_gates: list[str] | None = None
-    """List of basis gate names to unroll to.
+    """Deprecated field.
 
-    For example, ``['u1', 'u2', 'u3', 'cx']``. Unrolling is not done if not set.
-
-    Default: ``None``, implying all basis gates supported by the simulator.
+    Passed values will be ignored.
     """

--- a/ibm_quantum_schemas/models/noise_learner_v2/version_0_1_dev/options_model.py
+++ b/ibm_quantum_schemas/models/noise_learner_v2/version_0_1_dev/options_model.py
@@ -58,11 +58,9 @@ class SimulatorOptionsModel(BaseModel):
     """
 
     basis_gates: list[str] | None = None
-    """List of basis gate names to unroll to.
+    """ Deprecated field.
 
-    For example, ``['u1', 'u2', 'u3', 'cx']``. Unrolling is not done if not set.
-
-    Default: ``None``, implying all basis gates supported by the simulator.
+    Passed values will be ignored.
     """
 
 


### PR DESCRIPTION
The server ignores this field.
It can still appear in the protocol, so the Schema needs to include it, but I removed documentation for it.