### PR TITLE
Add incremental decoder Base64Reader

### DIFF
--- a/ibm_quantum_schemas/common/base64_reader.py
+++ b/ibm_quantum_schemas/common/base64_reader.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/ibm_quantum_schemas/common/base64_reader.py
+++ b/ibm_quantum_schemas/common/base64_reader.py
@@ -27,7 +27,7 @@ class Base64Reader(RawIOBase):
     class.
     """
 
-    def __init__(self, b64_string, chunk_chars=4096):
+    def __init__(self, b64_string: str, chunk_chars: int = 4096):
         """Initialize a new instance.
 
         Args:
@@ -57,8 +57,16 @@ class Base64Reader(RawIOBase):
         if tail:
             yield b64decode(tail)
 
-    def read(self, size=-1):
-        """Read a given number of bytes from the string."""
+    def read(self, size: int = -1):
+        """Read a given number of bytes from the string.
+
+        Args:
+            size: How many characters to read from the current position, where ``-1`` indicates to
+                read until the end of the file.
+
+        Returns:
+            The characters.
+        """
         while size < 0 or len(self._buffer) < size:
             try:
                 self._buffer += next(self._iter)

--- a/ibm_quantum_schemas/common/base64_reader.py
+++ b/ibm_quantum_schemas/common/base64_reader.py
@@ -1,0 +1,72 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Base64Reader"""
+
+from collections.abc import Iterable
+from io import RawIOBase
+
+from pybase64 import b64decode
+
+
+class Base64Reader(RawIOBase):
+    """A readable file-like for incrementally decoding a base64-encoded string.
+
+    Use this reader when you only need a leading chunk of a base64-encoded string.
+    If you need to read the whole thing, you are likely better off using
+    ``io.BytesIO(base64decode(string))`` because it avoids the Python overhead introduced by this
+    class.
+    """
+
+    def __init__(self, b64_string, chunk_chars=4096):
+        """Initialize a new instance.
+
+        Args:
+            b64_string: The base-64 string to read.
+            chunk_chars: How many characters to decode at a time.
+        """
+        if chunk_chars % 4 != 0:
+            raise ValueError("chunk_chars must be a multiple of 4")
+
+        self._iter = self._iter_b64decoded_bytes(b64_string, chunk_chars)
+        self._buffer = b""
+
+    @staticmethod
+    def _iter_b64decoded_bytes(b64_string: str, chunk_chars: int = 4096) -> Iterable[bytes]:
+        tail = ""
+
+        for i in range(0, len(b64_string), chunk_chars):
+            chunk = tail + b64_string[i : i + chunk_chars]
+
+            # Only decode full 4-char blocks
+            valid_len = (len(chunk) // 4) * 4
+            to_decode, tail = chunk[:valid_len], chunk[valid_len:]
+
+            if to_decode:
+                yield b64decode(to_decode)
+
+        if tail:
+            yield b64decode(tail)
+
+    def read(self, size=-1):
+        """Read a given number of bytes from the string."""
+        while size < 0 or len(self._buffer) < size:
+            try:
+                self._buffer += next(self._iter)
+            except StopIteration:
+                break
+
+        if size < 0:
+            out, self._buffer = self._buffer, b""
+        else:
+            out, self._buffer = self._buffer[:size], self._buffer[size:]
+        return out

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -15,13 +15,14 @@
 import struct
 from io import BytesIO
 
-import pybase64
+from pybase64 import b64decode, b64encode
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from qiskit import QuantumCircuit
 from qiskit.qpy import QPY_VERSION, dump, load
 from qiskit.qpy.formats import FILE_HEADER_V10, FILE_HEADER_V10_PACK, FILE_HEADER_V10_SIZE
 
 from ibm_quantum_schemas.common.annotation_serializer import AnnotationSerializer
+from ibm_quantum_schemas.common.base64_reader import Base64Reader
 
 ANNOTATION_FACTORIES = {"samplomatic": AnnotationSerializer}
 
@@ -40,7 +41,7 @@ class QpyModel(BaseModel):
     @model_validator(mode="after")
     def cross_validate_qpy_version(self):
         """Check that the reported version matches the encoded version."""
-        with BytesIO(pybase64.b64decode(self.circuit_b64)) as bytes_obj:
+        with Base64Reader(self.circuit_b64) as bytes_obj:
             header = FILE_HEADER_V10._make(
                 struct.unpack(
                     FILE_HEADER_V10_PACK,
@@ -72,7 +73,7 @@ class QpyModel(BaseModel):
             A quantum circuit.
         """
         if not use_cached or not hasattr(self, "_circuit"):
-            with BytesIO(pybase64.b64decode(self.circuit_b64)) as bytes_obj:
+            with BytesIO(b64decode(self.circuit_b64)) as bytes_obj:
                 self._circuit = load(bytes_obj, annotation_factories=ANNOTATION_FACTORIES)[0]
 
         return self._circuit
@@ -95,7 +96,7 @@ class QpyModel(BaseModel):
         """
         with BytesIO() as bytes_obj:
             dump(circuit, bytes_obj, version=qpy_version, annotation_factories=ANNOTATION_FACTORIES)
-            circuit_b64 = pybase64.b64encode(bytes_obj.getvalue()).decode()
+            circuit_b64 = b64encode(bytes_obj.getvalue()).decode()
 
         obj = cls(circuit_b64=circuit_b64, qpy_version=qpy_version)
         obj._circuit = circuit  # noqa: SLF001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic>=2.5,<3.0.0",
     "qiskit>=2.2.0,<3.0.0",
     "samplomatic>=0.12.0",
+    "pybase64>=1.3.0"
 ]
 
 [tool.setuptools_scm]

--- a/test/common/test_base64_reader.py
+++ b/test/common/test_base64_reader.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/common/test_base64_reader.py
+++ b/test/common/test_base64_reader.py
@@ -1,0 +1,107 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Base64Reader"""
+
+import pybase64
+import pytest
+
+from ibm_quantum_schemas.common.base64_reader import Base64Reader
+
+
+def test_full_read_matches_direct_decode():
+    """Reading the full stream matches direct base64 decoding."""
+    data = b"The quick brown fox jumps over the lazy dog"
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64)
+    result = reader.read()
+
+    assert result == data
+
+
+def test_partial_read_prefix():
+    """Partial reads return the correct decoded prefix."""
+    data = b"abcdefghijklmnopqrstuvwxyz"
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64)
+    head = reader.read(10)
+
+    assert head == data[:10]
+
+
+def test_multiple_small_reads():
+    """Multiple successive reads reconstruct the full decoded payload."""
+    data = b"0123456789" * 10
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64)
+
+    chunks = []
+    for _ in range(10):
+        chunks.append(reader.read(10))
+
+    assert b"".join(chunks) == data
+
+
+def test_read_past_eof():
+    """Reads past EOF return empty bytes without error."""
+    data = b"hello"
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64)
+
+    assert reader.read(5) == data
+    assert reader.read(5) == b""
+    assert reader.read() == b""
+
+
+def test_chunk_boundary_behavior():
+    """Decoding remains correct across base64 chunk boundaries."""
+    data = b"a" * 1000
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64, chunk_chars=8)
+
+    out = bytearray()
+    while True:
+        chunk = reader.read(7)
+        if not chunk:
+            break
+        out.extend(chunk)
+
+    assert bytes(out) == data
+
+
+def test_empty_input():
+    """Empty base64 input produces empty output."""
+    reader = Base64Reader("")
+    assert reader.read() == b""
+    assert reader.read(10) == b""
+
+
+def test_binary_data():
+    """Arbitrary binary data round-trips through the reader."""
+    data = bytes(range(256))
+    b64 = pybase64.b64encode(data).decode()
+
+    reader = Base64Reader(b64)
+    result = reader.read()
+
+    assert result == data
+
+
+def test_invalid_chunk_size():
+    """Non–4-multiple chunk sizes are rejected."""
+    with pytest.raises(ValueError):
+        Base64Reader("AAAA", chunk_chars=5)


### PR DESCRIPTION
This PR implements a simple file-like interface to a base64 string that does not require decoding the entire string to read just the first part of it.

This is not a current bottleneck, the time to validate is still dominated by calling `to_quantum_circuit()` inside of validation. However, I expect this will be more relevant for #105 when we put all circuits into one very massive string, and we still want to be able to efficiently check the qpy version.