### PR TITLE
Add QpyCircuitListModel

### DIFF
--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,10 @@
 """QpyModel"""
 
 import struct
+from collections.abc import Iterable
+from dataclasses import dataclass
 from io import BytesIO
+from typing import Self
 
 from pybase64 import b64decode, b64encode
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -25,6 +28,36 @@ from ibm_quantum_schemas.common.annotation_serializer import AnnotationSerialize
 from ibm_quantum_schemas.common.base64_reader import Base64Reader
 
 ANNOTATION_FACTORIES = {"samplomatic": AnnotationSerializer}
+
+
+@dataclass(frozen=True, slots=True)
+class QpyInfo:
+    """Information about the contents of a QPY file."""
+
+    qpy_version: int
+    """The QPY verson."""
+
+    num_programs: int
+    """The number of independent components inside the file."""
+
+
+def extract_qpy_info(qpy_b64: str) -> QpyInfo:
+    """Return information about a QPY binary stream.
+
+    Args:
+        qpy_b64: A QPY file encoded as a base64 string.
+
+    Returns:
+        Information about the QPY content.
+    """
+    with Base64Reader(qpy_b64) as bytes_obj:
+        header = FILE_HEADER_V10._make(
+            struct.unpack(
+                FILE_HEADER_V10_PACK,
+                bytes_obj.read(FILE_HEADER_V10_SIZE),
+            )
+        )
+    return QpyInfo(header.qpy_version, header.num_programs)
 
 
 class QpyModel(BaseModel):
@@ -41,22 +74,16 @@ class QpyModel(BaseModel):
     @model_validator(mode="after")
     def cross_validate_qpy_version(self):
         """Check that the reported version matches the encoded version."""
-        with Base64Reader(self.circuit_b64) as bytes_obj:
-            header = FILE_HEADER_V10._make(
-                struct.unpack(
-                    FILE_HEADER_V10_PACK,
-                    bytes_obj.read(FILE_HEADER_V10_SIZE),
-                )
+        qpy_info = extract_qpy_info(self.circuit_b64)
+        if qpy_info.qpy_version != self.qpy_version:
+            raise ValueError(
+                f"The qpy_version is {self.qpy_version} but the encoded QPY "
+                f"version is {qpy_info.qpy_version}."
             )
-            if header.qpy_version != self.qpy_version:
-                raise ValueError(
-                    f"The qpy_version is {self.qpy_version} but the encoded QPY "
-                    f"version is {header.qpy_version}."
-                )
-            if header.num_programs != 1:
-                raise ValueError(
-                    f"Expected exactly one encoded quantum circuit, received {header.num_programs}"
-                )
+        if qpy_info.num_programs != 1:
+            raise ValueError(
+                f"Expected exactly one encoded quantum circuit, received {qpy_info.num_programs}"
+            )
         return self
 
     def to_quantum_circuit(self, use_cached: bool = False) -> QuantumCircuit:
@@ -79,7 +106,7 @@ class QpyModel(BaseModel):
         return self._circuit
 
     @classmethod
-    def from_quantum_circuit(cls, circuit: QuantumCircuit, qpy_version: int = QPY_VERSION):
+    def from_quantum_circuit(cls, circuit: QuantumCircuit, qpy_version: int = QPY_VERSION) -> Self:
         """Create a model instance from a quantum circuit.
 
         The returned instance owns a reference to the provided circuit. This instance may be
@@ -111,5 +138,82 @@ class QpyModelV13ToV16(QpyModel):
 
 class QpyModelV13ToV17(QpyModel):
     """QPY encoded circuits with restricted version range."""
+
+    qpy_version: int = Field(ge=13, le=17)
+
+
+class QpyCircuitListModel(BaseModel):
+    """A QPY-encoded list of quantum circuits."""
+
+    circuits_b64: str
+    """Base-64 encoded data of the QPY serialization of a list of quantum circuits."""
+
+    qpy_version: int = Field(ge=10)
+    """The QPY encoding version."""
+
+    _circuits: list[QuantumCircuit] = PrivateAttr()
+
+    @model_validator(mode="after")
+    def cross_validate_qpy_version(self):
+        """Check that the reported version matches the encoded version."""
+        qpy_info = extract_qpy_info(self.circuits_b64)
+        if qpy_info.qpy_version != self.qpy_version:
+            raise ValueError(
+                f"The qpy_version is {self.qpy_version} but the encoded QPY "
+                f"version is {qpy_info.qpy_version}."
+            )
+        return self
+
+    def to_quantum_circuits(self, use_cached: bool = False) -> list[QuantumCircuit]:
+        """Return a decoded quantum circuit instance.
+
+        When ``use_cached`` is false, or when no cached version exists, :attr:`~circuits_b64` is
+        decoded and loaded into a new instance. Users of this class are responsible for managing
+        cached instances of the circuit and possible side-effects of their mutations.
+
+        Args:
+            use_cached: Whether to return the cached instance (if it exists).
+
+        Returns:
+            A quantum circuit.
+        """
+        if not use_cached or not hasattr(self, "_circuits"):
+            with BytesIO(b64decode(self.circuits_b64)) as bytes_obj:
+                self._circuits = load(bytes_obj, annotation_factories=ANNOTATION_FACTORIES)
+
+        return self._circuits
+
+    @classmethod
+    def from_quantum_circuits(
+        cls, circuits: Iterable[QuantumCircuit], qpy_version: int = QPY_VERSION
+    ) -> Self:
+        """Create a model instance from a quantum circuit.
+
+        The returned instance owns a reference to the provided circuit. This instance may be
+        returned by :meth:`~to_quantum_circuit` depending on the value of ``use_cached``.
+        Users of this class are responsible for managing cached instances of the circuit and
+        possible side-effects of their mutations.
+
+        Args:
+            circuit: The circuit to encode into the model.
+            qpy_version: The QPY version to encode with.
+
+        Returns:
+            A new model instance.
+        """
+        circuits = list(circuits)
+        with BytesIO() as bytes_obj:
+            dump(
+                circuits, bytes_obj, version=qpy_version, annotation_factories=ANNOTATION_FACTORIES
+            )
+            circuits_b64 = b64encode(bytes_obj.getvalue()).decode()
+
+        obj = cls(circuits_b64=circuits_b64, qpy_version=qpy_version)
+        obj._circuits = circuits  # noqa: SLF001
+        return obj
+
+
+class QpyCircuitListModelV13ToV17(QpyCircuitListModel):
+    """QPY encoded circuit list with restricted version range."""
 
     qpy_version: int = Field(ge=13, le=17)

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -16,13 +16,13 @@ import struct
 from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Self
 
 from pybase64 import b64decode, b64encode
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from qiskit import QuantumCircuit
 from qiskit.qpy import QPY_VERSION, dump, load
 from qiskit.qpy.formats import FILE_HEADER_V10, FILE_HEADER_V10_PACK, FILE_HEADER_V10_SIZE
+from typing_extensions import Self
 
 from ibm_quantum_schemas.common.annotation_serializer import AnnotationSerializer
 from ibm_quantum_schemas.common.base64_reader import Base64Reader

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -12,11 +12,36 @@
 
 """Tests for QPY models."""
 
+from io import BytesIO
+
 import pytest
+from pybase64 import b64encode
 from qiskit.circuit import QuantumCircuit
+from qiskit.qpy import dump
 from samplomatic import ChangeBasis, InjectNoise, Twirl
 
-from ibm_quantum_schemas.common.qpy import QpyModelV13ToV16, QpyModelV13ToV17
+from ibm_quantum_schemas.common.qpy import (
+    QpyCircuitListModelV13ToV17,
+    QpyModelV13ToV16,
+    QpyModelV13ToV17,
+    extract_qpy_info,
+)
+
+
+@pytest.mark.parametrize("qpy_version", [15, 16])
+@pytest.mark.parametrize("num_circuits", [1, 3])
+def test_extract_qpy_info(qpy_version, num_circuits):
+    """Test the ``extract_qpy_info`` function."""
+    circuit = QuantumCircuit(3)
+    circuit.measure_all()
+
+    with BytesIO() as bytes_buf:
+        dump([circuit] * num_circuits, bytes_buf, version=qpy_version)
+        qpy_str = b64encode(bytes_buf.getvalue()).decode()
+
+    info = extract_qpy_info(qpy_str)
+    assert info.qpy_version == qpy_version
+    assert info.num_programs == num_circuits
 
 
 class TestQpyModelV13ToV16:
@@ -107,3 +132,55 @@ class TestQpyModelV13ToV17:
 
         with pytest.raises(ValueError):
             QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version)
+
+
+class TestQpyCircuitListModelV13ToV17:
+    """Tests for ``QpyModelV13ToV17``."""
+
+    @pytest.mark.skip_if_qiskit_too_old_for_qpy
+    @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
+    def test_roundtrip(self, qpy_version):
+        """Test that round trips work correctly."""
+        circuit0 = QuantumCircuit(3)
+        circuit0.h(0)
+        circuit0.cx(0, 1)
+        circuit0.measure_all()
+
+        circuit1 = QuantumCircuit(2)
+        circuit0.h(0)
+        circuit0.measure_all()
+
+        circuits = [circuit0, circuit1]
+
+        encoded = QpyCircuitListModelV13ToV17.from_quantum_circuits(circuits, qpy_version)
+        circuits_out = encoded.to_quantum_circuits()
+
+        assert circuits == circuits_out
+
+    @pytest.mark.skip_if_qiskit_too_old_for_qpy
+    @pytest.mark.parametrize("qpy_version", [15, 16, 17])
+    def test_roundtrip_with_annotations(self, qpy_version):
+        """Test that round trips work correctly for circuits with annotated boxes."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+            circuit.cx(1, 2)
+        circuit.measure_all()
+
+        encoded = QpyCircuitListModelV13ToV17.from_quantum_circuits([circuit], qpy_version)
+        circuits_out = encoded.to_quantum_circuits()
+
+        assert len(circuits_out) == 1
+        assert circuit == circuits_out[0]
+
+    @pytest.mark.parametrize("qpy_version", [12, 18])
+    def test_unsupported_versions_raise(self, qpy_version):
+        """Test that unsupported versions raise."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+
+        with pytest.raises(ValueError):
+            QpyCircuitListModelV13ToV17.from_quantum_circuits([circuit], qpy_version)


### PR DESCRIPTION
This PR adds a new common model class. It's in support of #107, but stops shy of closing it by not actually changing the QuantumProgram model---I'd prefer that to be a separate PR.

Because different QPY versions can technically have different headers, I also decided to abstract that out into a new class `QpyInfo`. This buys a small amount of future safety.

I wish that `qiskit_ibm_schemas/common/qpy` had been set up differently: we should have just had a generic QpyModel that doesn't make assumptions about the content, and then subclass off of that. As it stands, though, QpyModel explicitly stores a single circuit. Maybe this PR should be updated to add a base class? I don't think we can do it in a way that fixes QpyModel though, since we can't affect the old schemas no matter what we do.