### PR TITLE
Change docstrings of NLV3 `ParamModel`s

### DIFF
--- a/ibm_quantum_schemas/executor/version_0_1/models.py
+++ b/ibm_quantum_schemas/executor/version_0_1/models.py
@@ -29,7 +29,7 @@ from ibm_quantum_schemas.common import SamplexModelSSV1 as SamplexModel
 
 
 class ParamsModel(BaseParamsModel):
-    """Schema version 1 of the inner parameters."""
+    """A model describing the Executor program inputs."""
 
     schema_version: Literal["v0.1"] = "v0.1"
 

--- a/ibm_quantum_schemas/noise_learner_v2/version_0_1/models.py
+++ b/ibm_quantum_schemas/noise_learner_v2/version_0_1/models.py
@@ -25,7 +25,7 @@ from ibm_quantum_schemas.noise_learner_v2.version_0_1.results_metadata import (
 
 
 class ParamsModel(BaseModel):
-    """A model describing the NoiseLearnerV2 program inputs, also known as "params"."""
+    """A model describing the NoiseLearnerV2 program inputs."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/ibm_quantum_schemas/noise_learner_v3/version_0_1/models.py
+++ b/ibm_quantum_schemas/noise_learner_v3/version_0_1/models.py
@@ -24,7 +24,7 @@ from ibm_quantum_schemas.common import (
 
 
 class ParamsModel(BaseParamsModel):
-    """Schema version 1 of the inner parameters."""
+    """A model describing the Noise Learner V3 program inputs."""
 
     schema_version: Literal["v0.1"] = "v0.1"
 

--- a/ibm_quantum_schemas/noise_learner_v3/version_0_2/models.py
+++ b/ibm_quantum_schemas/noise_learner_v3/version_0_2/models.py
@@ -26,7 +26,7 @@ from ibm_quantum_schemas.common import (
 
 
 class ParamsModel(BaseParamsModel):
-    """Schema version 1 of the inner parameters."""
+    """A model describing the Noise Learner V3 program inputs."""
 
     schema_version: Literal["v0.2"] = "v0.2"
 


### PR DESCRIPTION
Both versions 0.1 and 0.2 of NLV3 contain this docstring: https://github.com/Qiskit/ibm-quantum-schemas/blob/afb41cdbff2b1d500a09d784a16b65d3db9c4bce/ibm_quantum_schemas/noise_learner_v3/version_0_2/models.py#L28-L29

I'm not sure what "version 1" means, and whether it should be replaced with "version 2" in Version 0.2. I figured that the best option would be to copy the Executor's docstring, replacing of course the word `Executor` with `Noise Learner V3`.
