### PR TITLE
Avoid failing test with older samplomatic version

### DIFF
--- a/test/executor/version_0_1/test_models.py
+++ b/test/executor/version_0_1/test_models.py
@@ -111,7 +111,7 @@ def test_chunk_size_validation():
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, 16),
+        circuit=QpyModelV13ToV16.from_quantum_circuit(circuit, qpy_version=16),
         circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
     )

--- a/test/executor/version_0_2/test_models.py
+++ b/test/executor/version_0_2/test_models.py
@@ -117,19 +117,21 @@ def test_initialization_results_model():
 
 
 @pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.skip_if_qiskit_too_old_for_qpy
 @pytest.mark.parametrize("ssv", [1, 2])
-def test_chunk_size_validation(ssv):
+@pytest.mark.parametrize("qpy_version", [16, 17])
+def test_chunk_size_validation(ssv, qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(circuit, qpy_version=qpy_version),
         circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
     )
 
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        circuit=QpyModelV13ToV17.from_quantum_circuit(template, 16),
+        circuit=QpyModelV13ToV17.from_quantum_circuit(template, qpy_version=qpy_version),
         samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))

--- a/test/executor/version_0_2/test_models.py
+++ b/test/executor/version_0_2/test_models.py
@@ -116,7 +116,9 @@ def test_initialization_results_model():
     assert results.passthrough_data is None
 
 
-def test_chunk_size_validation():
+@pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.parametrize("ssv", [1, 2])
+def test_chunk_size_validation(ssv):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
@@ -128,7 +130,7 @@ def test_chunk_size_validation():
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
         circuit=QpyModelV13ToV17.from_quantum_circuit(template, 16),
-        samplex=SamplexModel.from_samplex(samplex, ssv=1),
+        samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))
         },

--- a/test/executor/version_1_0/test_models.py
+++ b/test/executor/version_1_0/test_models.py
@@ -146,7 +146,9 @@ def test_initialization_results_model():
     assert results.passthrough_data is None
 
 
-def test_chunk_size_validation():
+@pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.parametrize("ssv", [1, 2, 3])
+def test_chunk_size_validation(ssv):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
@@ -157,7 +159,7 @@ def test_chunk_size_validation():
 
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        samplex=SamplexModel.from_samplex(samplex, ssv=1),
+        samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))
         },

--- a/test/executor/version_1_0/test_models.py
+++ b/test/executor/version_1_0/test_models.py
@@ -147,8 +147,10 @@ def test_initialization_results_model():
 
 
 @pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.skip_if_qiskit_too_old_for_qpy
 @pytest.mark.parametrize("ssv", [1, 2, 3])
-def test_chunk_size_validation(ssv):
+@pytest.mark.parametrize("qpy_version", [16, 17])
+def test_chunk_size_validation(ssv, qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
@@ -170,7 +172,7 @@ def test_chunk_size_validation(ssv):
     with pytest.raises(ValueError, match="all items must specify one or the other"):
         QuantumProgramModel(
             shots=1000,
-            circuits=QpyDataModel.from_python([circuit, template], 16),
+            circuits=QpyDataModel.from_python([circuit, template], qpy_version=qpy_version),
             items=[circuit_item, samplex_item],
         )
 

--- a/test/executor/version_1_1/test_models.py
+++ b/test/executor/version_1_1/test_models.py
@@ -146,7 +146,9 @@ def test_initialization_results_model():
     assert results.passthrough_data is None
 
 
-def test_chunk_size_validation():
+@pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.parametrize("ssv", [4])
+def test_chunk_size_validation(ssv):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(

--- a/test/executor/version_1_1/test_models.py
+++ b/test/executor/version_1_1/test_models.py
@@ -147,8 +147,10 @@ def test_initialization_results_model():
 
 
 @pytest.mark.skip_if_samplomatic_too_old_for_ssv
+@pytest.mark.skip_if_qiskit_too_old_for_qpy
 @pytest.mark.parametrize("ssv", [1, 2, 3, 4])
-def test_chunk_size_validation(ssv):
+@pytest.mark.parametrize("qpy_version", [16, 17])
+def test_chunk_size_validation(ssv, qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
@@ -170,7 +172,7 @@ def test_chunk_size_validation(ssv):
     with pytest.raises(ValueError, match="all items must specify one or the other"):
         QuantumProgramModel(
             shots=1000,
-            circuits=QpyDataModel.from_python([circuit, template], 16),
+            circuits=QpyDataModel.from_python([circuit, template], qpy_version=qpy_version),
             items=[circuit_item, samplex_item],
         )
 

--- a/test/executor/version_1_1/test_models.py
+++ b/test/executor/version_1_1/test_models.py
@@ -159,7 +159,7 @@ def test_chunk_size_validation(ssv):
 
     template, samplex = build(circuit)
     samplex_item = SamplexItemModel(
-        samplex=SamplexModel.from_samplex(samplex, ssv=4),
+        samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
             "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))
         },

--- a/test/executor/version_1_1/test_models.py
+++ b/test/executor/version_1_1/test_models.py
@@ -147,7 +147,7 @@ def test_initialization_results_model():
 
 
 @pytest.mark.skip_if_samplomatic_too_old_for_ssv
-@pytest.mark.parametrize("ssv", [4])
+@pytest.mark.parametrize("ssv", [1, 2, 3, 4])
 def test_chunk_size_validation(ssv):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Technically, the `0.8.x` releases would not pass the test suite if  the version of `samplomatic` installed is not the most recent version. This takes advantage of the existing machinery to skip the test that depends on `ssv` 4.

### Details and comments

Tested locally by downgrading `samplomatic` to `0.12`, and having the test skip.

Related to #149
