### PR TITLE
Executor v2.0 schema - Add ability to compress fields

### DIFF
--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -38,6 +38,8 @@ Classes
    SamplexModelSSV1ToSSV2
    TensorModel
    F64TensorModel
+   CompressableTensorModel
+   F64CompressableTensorModel
 """
 
 from ibm_quantum_schemas.common.base_params import BaseParamsModel
@@ -56,4 +58,9 @@ from ibm_quantum_schemas.common.samplex import (
     SamplexModelSSV1ToSSV3,
     SamplexModelSSV1ToSSV4,
 )
-from ibm_quantum_schemas.common.tensor import F64TensorModel, TensorModel
+from ibm_quantum_schemas.common.tensor import (
+    CompressableTensorModel,
+    F64CompressableTensorModel,
+    F64TensorModel,
+    TensorModel,
+)

--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -31,8 +31,8 @@ Classes
    QpyModel
    QpyModelV13ToV16
    QpyModelV13ToV17
-   CompressableQpyDataModel
-   CompressableQpyDataV13ToV17Model
+   CompressedQpyDataModel
+   CompressedQpyDataV13ToV17Model
    BaseParamsModel
    PauliLindbladMapModel
    SamplexModel
@@ -40,15 +40,15 @@ Classes
    SamplexModelSSV1ToSSV2
    TensorModel
    F64TensorModel
-   CompressableTensorModel
-   F64CompressableTensorModel
+   CompressedTensorModel
+   F64CompressedTensorModel
 """
 
 from ibm_quantum_schemas.common.base_params import BaseParamsModel
 from ibm_quantum_schemas.common.pauli_lindblad_map import PauliLindbladMapModel
 from ibm_quantum_schemas.common.qpy import (
-    CompressableQpyDataModel,
-    CompressableQpyDataV13ToV17Model,
+    CompressedQpyDataModel,
+    CompressedQpyDataV13ToV17Model,
     QpyDataModel,
     QpyDataV13ToV17Model,
     QpyModel,
@@ -63,8 +63,8 @@ from ibm_quantum_schemas.common.samplex import (
     SamplexModelSSV1ToSSV4,
 )
 from ibm_quantum_schemas.common.tensor import (
-    CompressableTensorModel,
-    F64CompressableTensorModel,
+    CompressedTensorModel,
+    F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
 )

--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -31,6 +31,8 @@ Classes
    QpyModel
    QpyModelV13ToV16
    QpyModelV13ToV17
+   CompressableQpyDataModel
+   CompressableQpyDataV13ToV17Model
    BaseParamsModel
    PauliLindbladMapModel
    SamplexModel
@@ -45,6 +47,8 @@ Classes
 from ibm_quantum_schemas.common.base_params import BaseParamsModel
 from ibm_quantum_schemas.common.pauli_lindblad_map import PauliLindbladMapModel
 from ibm_quantum_schemas.common.qpy import (
+    CompressableQpyDataModel,
+    CompressableQpyDataV13ToV17Model,
     QpyDataModel,
     QpyDataV13ToV17Model,
     QpyModel,

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -60,14 +60,10 @@ def extract_qpy_info(qpy_b64: str, compressed: bool = False) -> QpyInfo:
             decompressor = zlib.decompressobj()
             buffer = b""
             while len(buffer) < FILE_HEADER_V10_SIZE:
-                chunk = bytes_obj.read()
+                chunk = bytes_obj.read(4096)
                 if not chunk:
                     break
                 buffer += decompressor.decompress(chunk)
-
-            if len(buffer) < FILE_HEADER_V10_SIZE:
-                buffer += decompressor.flush()
-
             buffer = buffer[:FILE_HEADER_V10_SIZE]
         else:
             buffer = bytes_obj.read(FILE_HEADER_V10_SIZE)

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -56,6 +56,9 @@ def extract_qpy_info(qpy_b64: str, compressed: bool = False) -> QpyInfo:
         Information about the QPY content.
     """
     with Base64Reader(qpy_b64) as bytes_obj:
+        # to avoid reading the full string into memory for compressed data,
+        # read in as chunks of 4096 bytes and decompress until the buffer
+        # contains `FILE_HEADER_V10`
         if compressed:
             decompressor = zlib.decompressobj()
             buffer = b""
@@ -145,16 +148,13 @@ class QpyDataModel(BaseModel, Generic[T]):
         return obj
 
 
-class CompressableQpyDataModel(QpyDataModel[T], Generic[T]):
-    """QPY-encoded Qiskit objects with optional compression."""
-
-    compressed: bool = False
-    """Whether the data has been compressed."""
+class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
+    """QPY-encoded Qiskit objects with compression."""
 
     @model_validator(mode="after")
     def cross_validate_qpy_info(self):
         """Check that the encoded qpy information matches expectations."""
-        qpy_info = extract_qpy_info(self.b64_data, compressed=self.compressed)
+        qpy_info = extract_qpy_info(self.b64_data, compressed=True)
         if qpy_info.qpy_version != self.qpy_version:
             raise ValueError(
                 f"The qpy_version is {self.qpy_version} but the encoded QPY "
@@ -181,18 +181,14 @@ class CompressableQpyDataModel(QpyDataModel[T], Generic[T]):
             Python data.
         """
         if not use_cached or not hasattr(self, "_python_data"):
-            raw_data = b64decode(self.b64_data)
-            if self.compressed:
-                raw_data = zlib.decompress(raw_data)
+            raw_data = zlib.decompress(b64decode(self.b64_data))
             with BytesIO(raw_data) as bytes_obj:
                 self._python_data = load(bytes_obj, annotation_factories=ANNOTATION_FACTORIES)
 
         return self._python_data
 
     @classmethod
-    def from_python(
-        cls, data: list[T], qpy_version: int = QPY_VERSION, compress: bool = True
-    ) -> Self:
+    def from_python(cls, data: list[T], qpy_version: int = QPY_VERSION) -> Self:
         """Create a model instance from Python data of the correct type.
 
         The returned instance owns a reference to the provided data. This instance may be
@@ -203,21 +199,16 @@ class CompressableQpyDataModel(QpyDataModel[T], Generic[T]):
         Args:
             data: The data to base64 encode in the new model instance.
             qpy_version: The QPY version to encode with.
-            compress: Whether to compress the encoded data.
 
         Returns:
             A new model instance.
         """
         with BytesIO() as bytes_obj:
             dump(data, bytes_obj, version=qpy_version, annotation_factories=ANNOTATION_FACTORIES)
-            raw_data = bytes_obj.getvalue()
-            if compress:
-                raw_data = zlib.compress(raw_data)
+            raw_data = zlib.compress(bytes_obj.getvalue())
             b64_data = b64encode(raw_data).decode("utf-8")
 
-        obj = cls(
-            b64_data=b64_data, qpy_version=qpy_version, num_programs=len(data), compressed=compress
-        )
+        obj = cls(b64_data=b64_data, qpy_version=qpy_version, num_programs=len(data))
         obj._python_data = data  # noqa: SLF001
         return obj
 
@@ -312,7 +303,7 @@ class QpyDataV13ToV17Model(QpyDataModel[T], Generic[T]):
     qpy_version: int = Field(ge=13, le=17)
 
 
-class CompressableQpyDataV13ToV17Model(CompressableQpyDataModel[T], Generic[T]):
+class CompressedQpyDataV13ToV17Model(CompressedQpyDataModel[T], Generic[T]):
     """Compressable QPY encoded circuit list with restricted version range."""
 
     qpy_version: int = Field(ge=13, le=17)

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -60,8 +60,7 @@ def extract_qpy_info(qpy_b64: str, compressed: bool = False) -> QpyInfo:
             decompressor = zlib.decompressobj()
             buffer = b""
             while len(buffer) < FILE_HEADER_V10_SIZE:
-                chunk = bytes_obj.read(4096)
-                if not chunk:
+                if not (chunk := bytes_obj.read(4096)):
                     break
                 buffer += decompressor.decompress(chunk)
             buffer = buffer[:FILE_HEADER_V10_SIZE]

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -13,6 +13,7 @@
 """QpyModel"""
 
 import struct
+import zlib
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Generic, TypeVar
@@ -137,6 +138,90 @@ class QpyDataModel(BaseModel, Generic[T]):
         return obj
 
 
+class CompressableQpyDataModel(QpyDataModel[T], Generic[T]):
+    """QPY-encoded Qiskit objects with optional compression."""
+
+    compressed: bool = False
+    """Whether the data has been compressed."""
+
+    @model_validator(mode="after")
+    def cross_validate_qpy_info(self):
+        """Check that the encoded qpy information matches expectations."""
+        if self.compressed:
+            b64_data = b64decode(self.b64_data)
+            decompressed_data = zlib.decompress(b64_data)
+            b64_data = b64encode(decompressed_data).decode()
+        else:
+            b64_data = self.b64_data
+
+        qpy_info = extract_qpy_info(b64_data)
+        if qpy_info.qpy_version != self.qpy_version:
+            raise ValueError(
+                f"The qpy_version is {self.qpy_version} but the encoded QPY "
+                f"version is {qpy_info.qpy_version}."
+            )
+        if qpy_info.num_programs != self.num_programs:
+            raise ValueError(
+                f"num_programs={self.num_programs}, but the encoded QPY "
+                f"has {qpy_info.num_programs} elements"
+            )
+        return self
+
+    def to_python(self, use_cached: bool = False) -> list[T]:
+        """Return a Python representation of the encoded data in the model.
+
+        When ``use_cached`` is false, or when no cached version exists, :attr:`~b64_data` is
+        decoded and loaded into a new Python instance. Users of this class are responsible for
+        managing cached instances of the Python data and possible side-effects of their mutations.
+
+        Args:
+            use_cached: Whether to return the cached instance (if it exists).
+
+        Returns:
+            Python data.
+        """
+        if not use_cached or not hasattr(self, "_python_data"):
+            raw_data = b64decode(self.b64_data)
+            if self.compressed:
+                raw_data = zlib.decompress(raw_data)
+            with BytesIO(raw_data) as bytes_obj:
+                self._python_data = load(bytes_obj, annotation_factories=ANNOTATION_FACTORIES)
+
+        return self._python_data
+
+    @classmethod
+    def from_python(
+        cls, data: list[T], qpy_version: int = QPY_VERSION, compress: bool = True
+    ) -> Self:
+        """Create a model instance from Python data of the correct type.
+
+        The returned instance owns a reference to the provided data. This instance may be
+        returned by :meth:`~to_python` depending on the value of ``use_cached``.
+        Users of this class are responsible for managing cached instances of the data and
+        possible side-effects of their mutations.
+
+        Args:
+            data: The data to base64 encode in the new model instance.
+            qpy_version: The QPY version to encode with.
+            compress: Whether to compress the encoded data.
+
+        Returns:
+            A new model instance.
+        """
+        with BytesIO() as bytes_obj:
+            dump(data, bytes_obj, version=qpy_version, annotation_factories=ANNOTATION_FACTORIES)
+            raw_data = bytes_obj.getvalue()
+            if compress:
+                raw_data = zlib.compress(raw_data)
+            b64_data = b64encode(raw_data).decode("utf-8")
+
+        obj = cls(
+            b64_data=b64_data, qpy_version=qpy_version, num_programs=len(data), compressed=compress
+        )
+        obj._python_data = data  # noqa: SLF001
+        return obj
+
+
 # This class does not use/inherit QpyDataModel for historical reasons. Since some program models
 # depend on it, we leave it as-is.
 class QpyModel(BaseModel):
@@ -223,5 +308,11 @@ class QpyModelV13ToV17(QpyModel):
 
 class QpyDataV13ToV17Model(QpyDataModel[T], Generic[T]):
     """QPY encoded circuit list with restricted version range."""
+
+    qpy_version: int = Field(ge=13, le=17)
+
+
+class CompressableQpyDataV13ToV17Model(CompressableQpyDataModel[T], Generic[T]):
+    """Compressable QPY encoded circuit list with restricted version range."""
 
     qpy_version: int = Field(ge=13, le=17)

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -45,22 +45,34 @@ class QpyInfo:
     """The number of independent components inside the file."""
 
 
-def extract_qpy_info(qpy_b64: str) -> QpyInfo:
+def extract_qpy_info(qpy_b64: str, compressed: bool = False) -> QpyInfo:
     """Return information about a QPY binary stream.
 
     Args:
         qpy_b64: A QPY file encoded as a base64 string.
+        compressed: Whether the data has been compressed.
 
     Returns:
         Information about the QPY content.
     """
     with Base64Reader(qpy_b64) as bytes_obj:
-        header = FILE_HEADER_V10._make(
-            struct.unpack(
-                FILE_HEADER_V10_PACK,
-                bytes_obj.read(FILE_HEADER_V10_SIZE),
-            )
-        )
+        if compressed:
+            decompressor = zlib.decompressobj()
+            raw_header = b""
+            while len(raw_header) < FILE_HEADER_V10_SIZE:
+                chunk = bytes_obj.read()
+                if not chunk:
+                    break
+                raw_header += decompressor.decompress(chunk)
+
+            if len(raw_header) < FILE_HEADER_V10_SIZE:
+                raw_header += decompressor.flush()
+
+            raw_header = raw_header[:FILE_HEADER_V10_SIZE]
+        else:
+            raw_header = bytes_obj.read(FILE_HEADER_V10_SIZE)
+
+        header = FILE_HEADER_V10._make(struct.unpack(FILE_HEADER_V10_PACK, raw_header))
     return QpyInfo(header.qpy_version, header.num_programs)
 
 
@@ -147,14 +159,7 @@ class CompressableQpyDataModel(QpyDataModel[T], Generic[T]):
     @model_validator(mode="after")
     def cross_validate_qpy_info(self):
         """Check that the encoded qpy information matches expectations."""
-        if self.compressed:
-            b64_data = b64decode(self.b64_data)
-            decompressed_data = zlib.decompress(b64_data)
-            b64_data = b64encode(decompressed_data).decode()
-        else:
-            b64_data = self.b64_data
-
-        qpy_info = extract_qpy_info(b64_data)
+        qpy_info = extract_qpy_info(self.b64_data, compressed=self.compressed)
         if qpy_info.qpy_version != self.qpy_version:
             raise ValueError(
                 f"The qpy_version is {self.qpy_version} but the encoded QPY "

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -58,21 +58,21 @@ def extract_qpy_info(qpy_b64: str, compressed: bool = False) -> QpyInfo:
     with Base64Reader(qpy_b64) as bytes_obj:
         if compressed:
             decompressor = zlib.decompressobj()
-            raw_header = b""
-            while len(raw_header) < FILE_HEADER_V10_SIZE:
+            buffer = b""
+            while len(buffer) < FILE_HEADER_V10_SIZE:
                 chunk = bytes_obj.read()
                 if not chunk:
                     break
-                raw_header += decompressor.decompress(chunk)
+                buffer += decompressor.decompress(chunk)
 
-            if len(raw_header) < FILE_HEADER_V10_SIZE:
-                raw_header += decompressor.flush()
+            if len(buffer) < FILE_HEADER_V10_SIZE:
+                buffer += decompressor.flush()
 
-            raw_header = raw_header[:FILE_HEADER_V10_SIZE]
+            buffer = buffer[:FILE_HEADER_V10_SIZE]
         else:
-            raw_header = bytes_obj.read(FILE_HEADER_V10_SIZE)
+            buffer = bytes_obj.read(FILE_HEADER_V10_SIZE)
 
-        header = FILE_HEADER_V10._make(struct.unpack(FILE_HEADER_V10_PACK, raw_header))
+        header = FILE_HEADER_V10._make(struct.unpack(FILE_HEADER_V10_PACK, buffer))
     return QpyInfo(header.qpy_version, header.num_programs)
 
 

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -304,6 +304,6 @@ class QpyDataV13ToV17Model(QpyDataModel[T], Generic[T]):
 
 
 class CompressedQpyDataV13ToV17Model(CompressedQpyDataModel[T], Generic[T]):
-    """Compressable QPY encoded circuit list with restricted version range."""
+    """Compressed QPY encoded circuit list with restricted version range."""
 
     qpy_version: int = Field(ge=13, le=17)

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -13,6 +13,7 @@
 """TensorModel"""
 
 import math
+import zlib
 from typing import Literal, TypeAlias, get_args
 
 import numpy as np
@@ -118,29 +119,34 @@ class CompressableTensorModel(TensorModel):
         """Instantiate from a NumPy array."""
         if array.dtype == np.dtype(np.float64):
             dtype = "f64"
-            data = pybase64.b64encode(array.astype("<f8").tobytes())
+            data = array.astype("<f8").tobytes()
         elif array.dtype == np.dtype(np.bool_):
             dtype = "bool"
-            packed = np.packbits(array.astype(np.uint8), bitorder="little")
-            data = pybase64.b64encode(packed.tobytes())
+            data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
         elif array.dtype == np.dtype(np.uint8):
             dtype = "u8"
-            data = pybase64.b64encode(array.astype("<u1").tobytes())
+            data = array.astype("<u1").tobytes()
         elif array.dtype == np.dtype(np.complex128):
             dtype = "c128"
-            data = pybase64.b64encode(array.astype("<c16").tobytes())
+            data = array.astype("<c16").tobytes()
         else:
             raise ValueError(
                 f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
                 "expected."
             )
 
+        if compress:
+            data = zlib.compress(data)
+
+        data = pybase64.b64encode(data).decode("utf-8")
         return cls(data=data, shape=array.shape, dtype=dtype, compressed=compress)
 
     def to_numpy(self) -> np.ndarray:
         """Convert to a NumPy Array."""
         shape = tuple(self.shape)
         raw = pybase64.b64decode(self.data)
+        if self.compressed:
+            raw = zlib.decompress(raw)
 
         if self.dtype == "f64":
             return np.frombuffer(raw, dtype="<f8").reshape(shape)
@@ -155,6 +161,21 @@ class CompressableTensorModel(TensorModel):
             return np.frombuffer(raw, dtype="<c16").reshape(shape)
 
         raise ValueError(f"dtype {self.dtype} not understood.")
+
+    @model_validator(mode="after")
+    def check_sizes(self):
+        """Cross-validate that all sizes are consistent."""
+        raw = pybase64.b64decode(self.data)
+        if self.compressed:
+            raw = zlib.decompress(raw)
+
+        elem_size = self._ELEM_SIZE_LOOKUP[self.dtype]
+        if math.ceil(len(raw) / elem_size) != math.prod(self.shape):
+            raise ValueError(
+                f"Data length {len(raw)} is inconsistent with shape {self.shape} packed at "
+                f"{elem_size} bytes per element."
+            )
+        return self
 
 
 class F64CompressableTensorModel(CompressableTensorModel):

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -105,3 +105,59 @@ class F64TensorModel(TensorModel):
     """Model of tensor data specialized to f64."""
 
     dtype: Literal["f64"] = "f64"
+
+
+class CompressableTensorModel(TensorModel):
+    """Model of tensor data specialized to compressable types."""
+
+    compressed: bool = True
+    """Whether the data has been compressed or not."""
+
+    @classmethod
+    def from_numpy(cls, array: np.ndarray, compress: bool = True):
+        """Instantiate from a NumPy array."""
+        if array.dtype == np.dtype(np.float64):
+            dtype = "f64"
+            data = pybase64.b64encode(array.astype("<f8").tobytes())
+        elif array.dtype == np.dtype(np.bool_):
+            dtype = "bool"
+            packed = np.packbits(array.astype(np.uint8), bitorder="little")
+            data = pybase64.b64encode(packed.tobytes())
+        elif array.dtype == np.dtype(np.uint8):
+            dtype = "u8"
+            data = pybase64.b64encode(array.astype("<u1").tobytes())
+        elif array.dtype == np.dtype(np.complex128):
+            dtype = "c128"
+            data = pybase64.b64encode(array.astype("<c16").tobytes())
+        else:
+            raise ValueError(
+                f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
+                "expected."
+            )
+
+        return cls(data=data, shape=array.shape, dtype=dtype, compressed=compress)
+
+    def to_numpy(self) -> np.ndarray:
+        """Convert to a NumPy Array."""
+        shape = tuple(self.shape)
+        raw = pybase64.b64decode(self.data)
+
+        if self.dtype == "f64":
+            return np.frombuffer(raw, dtype="<f8").reshape(shape)
+        elif self.dtype == "bool":
+            # Total number of elements from shape
+            total = np.prod(shape, dtype=int)
+            unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
+            return unpacked.astype(bool).reshape(shape)
+        elif self.dtype == "u8":
+            return np.frombuffer(raw, dtype="<u1").reshape(shape)
+        elif self.dtype == "c128":
+            return np.frombuffer(raw, dtype="<c16").reshape(shape)
+
+        raise ValueError(f"dtype {self.dtype} not understood.")
+
+
+class F64CompressableTensorModel(CompressableTensorModel):
+    """Model of compressable tensor data specialized to f64."""
+
+    dtype: Literal["f64"] = "f64"

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -19,9 +19,71 @@ from typing import Literal, TypeAlias, get_args
 import numpy as np
 import pybase64
 from pydantic import BaseModel, model_validator
+from typing_extensions import Buffer
 
 SupportedDtypes: TypeAlias = Literal["f64", "bool", "u8", "c128"]
 """The data types supported by :class:`~TensorModel`."""
+
+
+def _from_buffer(raw: Buffer, dtype: SupportedDtypes, shape: tuple[int, ...]) -> np.ndarray:
+    """Convert a buffer of bytes into a NumPy array of the specified dtype and shape.
+
+    Args:
+        raw: The buffer of bytes to convert.
+        dtype: The data type of the resulting NumPy array.
+        shape: The shape of the resulting NumPy array.
+
+    Returns:
+        A NumPy array of the specified dtype and shape.
+
+    Raises:
+        ValueError: If the dtype is not supported.
+    """
+    if dtype == "f64":
+        return np.frombuffer(raw, dtype="<f8").reshape(shape)
+    elif dtype == "bool":
+        # Total number of elements from shape
+        total = np.prod(shape, dtype=int)
+        unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
+        return unpacked.astype(bool).reshape(shape)
+    elif dtype == "u8":
+        return np.frombuffer(raw, dtype="<u1").reshape(shape)
+    elif dtype == "c128":
+        return np.frombuffer(raw, dtype="<c16").reshape(shape)
+
+    raise ValueError(f"dtype {dtype} not understood.")
+
+
+def _get_dtype_and_bytes(array: np.ndarray) -> tuple[SupportedDtypes, bytes]:
+    """Get the dtype string and bytes representation of a NumPy array.
+
+    Args:
+        array: The NumPy array to convert.
+
+    Returns:
+        A tuple containing the dtype string and the bytes representation of the array.
+
+    Raises:
+        ValueError: If the dtype of the array is not supported.
+    """
+    if array.dtype == np.dtype(np.float64):
+        dtype = "f64"
+        byte_data = array.astype("<f8").tobytes()
+    elif array.dtype == np.dtype(np.bool_):
+        dtype = "bool"
+        byte_data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
+    elif array.dtype == np.dtype(np.uint8):
+        dtype = "u8"
+        byte_data = array.astype("<u1").tobytes()
+    elif array.dtype == np.dtype(np.complex128):
+        dtype = "c128"
+        byte_data = array.astype("<c16").tobytes()
+    else:
+        raise ValueError(
+            f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
+            "expected."
+        )
+    return dtype, byte_data
 
 
 class TensorModel(BaseModel):
@@ -45,45 +107,15 @@ class TensorModel(BaseModel):
     @classmethod
     def from_numpy(cls, array: np.ndarray):
         """Instantiate from a NumPy array."""
-        if array.dtype == np.dtype(np.float64):
-            dtype = "f64"
-            data = pybase64.b64encode(array.astype("<f8").tobytes())
-        elif array.dtype == np.dtype(np.bool_):
-            dtype = "bool"
-            packed = np.packbits(array.astype(np.uint8), bitorder="little")
-            data = pybase64.b64encode(packed.tobytes())
-        elif array.dtype == np.dtype(np.uint8):
-            dtype = "u8"
-            data = pybase64.b64encode(array.astype("<u1").tobytes())
-        elif array.dtype == np.dtype(np.complex128):
-            dtype = "c128"
-            data = pybase64.b64encode(array.astype("<c16").tobytes())
-        else:
-            raise ValueError(
-                f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
-                "expected."
-            )
-
-        return cls(data=data, shape=array.shape, dtype=dtype)
+        dtype, data = _get_dtype_and_bytes(array)
+        encoded_data = pybase64.b64encode(data).decode("utf-8")
+        return cls(data=encoded_data, shape=array.shape, dtype=dtype)
 
     def to_numpy(self) -> np.ndarray:
         """Convert to a NumPy Array."""
         shape = tuple(self.shape)
         raw = pybase64.b64decode(self.data)
-
-        if self.dtype == "f64":
-            return np.frombuffer(raw, dtype="<f8").reshape(shape)
-        elif self.dtype == "bool":
-            # Total number of elements from shape
-            total = np.prod(shape, dtype=int)
-            unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
-            return unpacked.astype(bool).reshape(shape)
-        elif self.dtype == "u8":
-            return np.frombuffer(raw, dtype="<u1").reshape(shape)
-        elif self.dtype == "c128":
-            return np.frombuffer(raw, dtype="<c16").reshape(shape)
-
-        raise ValueError(f"dtype {self.dtype} not understood.")
+        return _from_buffer(raw, self.dtype, shape)
 
     @model_validator(mode="after")
     def check_sizes(self):
@@ -117,29 +149,11 @@ class CompressableTensorModel(TensorModel):
     @classmethod
     def from_numpy(cls, array: np.ndarray, compress: bool = True):
         """Instantiate from a NumPy array."""
-        if array.dtype == np.dtype(np.float64):
-            dtype = "f64"
-            data = array.astype("<f8").tobytes()
-        elif array.dtype == np.dtype(np.bool_):
-            dtype = "bool"
-            data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
-        elif array.dtype == np.dtype(np.uint8):
-            dtype = "u8"
-            data = array.astype("<u1").tobytes()
-        elif array.dtype == np.dtype(np.complex128):
-            dtype = "c128"
-            data = array.astype("<c16").tobytes()
-        else:
-            raise ValueError(
-                f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
-                "expected."
-            )
-
+        dtype, data = _get_dtype_and_bytes(array)
         if compress:
             data = zlib.compress(data)
-
-        data = pybase64.b64encode(data).decode("utf-8")
-        return cls(data=data, shape=array.shape, dtype=dtype, compressed=compress)
+        encoded_data = pybase64.b64encode(data).decode("utf-8")
+        return cls(data=encoded_data, shape=array.shape, dtype=dtype, compressed=compress)
 
     def to_numpy(self) -> np.ndarray:
         """Convert to a NumPy Array."""
@@ -147,20 +161,7 @@ class CompressableTensorModel(TensorModel):
         raw = pybase64.b64decode(self.data)
         if self.compressed:
             raw = zlib.decompress(raw)
-
-        if self.dtype == "f64":
-            return np.frombuffer(raw, dtype="<f8").reshape(shape)
-        elif self.dtype == "bool":
-            # Total number of elements from shape
-            total = np.prod(shape, dtype=int)
-            unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
-            return unpacked.astype(bool).reshape(shape)
-        elif self.dtype == "u8":
-            return np.frombuffer(raw, dtype="<u1").reshape(shape)
-        elif self.dtype == "c128":
-            return np.frombuffer(raw, dtype="<c16").reshape(shape)
-
-        raise ValueError(f"dtype {self.dtype} not understood.")
+        return _from_buffer(raw, self.dtype, shape)
 
     @model_validator(mode="after")
     def check_sizes(self):

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -140,36 +140,26 @@ class F64TensorModel(TensorModel):
     dtype: Literal["f64"] = "f64"
 
 
-class CompressableTensorModel(TensorModel):
-    """Model of tensor data specialized to compressable types."""
-
-    compressed: bool = True
-    """Whether the data has been compressed or not."""
+class CompressedTensorModel(TensorModel):
+    """Model of compressed tensor data."""
 
     @classmethod
-    def from_numpy(cls, array: np.ndarray, compress: bool = True):
+    def from_numpy(cls, array: np.ndarray):
         """Instantiate from a NumPy array."""
         dtype, data = _get_dtype_and_bytes(array)
-        if compress:
-            data = zlib.compress(data)
-        encoded_data = pybase64.b64encode(data).decode("utf-8")
-        return cls(data=encoded_data, shape=array.shape, dtype=dtype, compressed=compress)
+        encoded_data = pybase64.b64encode(zlib.compress(data)).decode("utf-8")
+        return cls(data=encoded_data, shape=array.shape, dtype=dtype)
 
     def to_numpy(self) -> np.ndarray:
         """Convert to a NumPy Array."""
         shape = tuple(self.shape)
-        raw = pybase64.b64decode(self.data)
-        if self.compressed:
-            raw = zlib.decompress(raw)
+        raw = zlib.decompress(pybase64.b64decode(self.data))
         return _from_buffer(raw, self.dtype, shape)
 
     @model_validator(mode="after")
     def check_sizes(self):
         """Cross-validate that all sizes are consistent."""
-        raw = pybase64.b64decode(self.data)
-        if self.compressed:
-            raw = zlib.decompress(raw)
-
+        raw = zlib.decompress(pybase64.b64decode(self.data))
         elem_size = self._ELEM_SIZE_LOOKUP[self.dtype]
         if math.ceil(len(raw) / elem_size) != math.prod(self.shape):
             raise ValueError(
@@ -179,7 +169,7 @@ class CompressableTensorModel(TensorModel):
         return self
 
 
-class F64CompressableTensorModel(CompressableTensorModel):
-    """Model of compressable tensor data specialized to f64."""
+class F64CompressedTensorModel(CompressedTensorModel):
+    """Model of compressed tensor data specialized to f64."""
 
     dtype: Literal["f64"] = "f64"

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -28,16 +28,18 @@ from ibm_quantum_schemas.common import (
     CompressableTensorModel,
     F64CompressableTensorModel,
     PauliLindbladMapModel,
+    TensorModel,
 )
 from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 
 # TypeAliasType is required for Pydantic to handle this recursive type correctly.
 # Note that TypeAliasType is a backport for Python<3.12, so that when drop Python 3.11 support and
 # lower, this can be updated to `type DataTree = ...`.
-# CompressableTensorModel must come before dict so Pydantic tries it first during deserialization.
+# TensorModel must come before dict so Pydantic tries it first during deserialization.
 DataTree = TypeAliasType(
     "DataTree",
     list["DataTree"]
+    | TensorModel
     | CompressableTensorModel
     | dict[str, "DataTree"]
     | str

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -24,20 +24,27 @@ from typing_extensions import TypeAliasType
 from ibm_quantum_schemas.aliases import Self
 from ibm_quantum_schemas.common import (
     BaseParamsModel,
-    F64TensorModel,
+    CompressableTensorModel,
+    F64CompressableTensorModel,
     PauliLindbladMapModel,
     QpyDataV13ToV17Model,
-    TensorModel,
 )
 from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 
 # TypeAliasType is required for Pydantic to handle this recursive type correctly.
 # Note that TypeAliasType is a backport for Python<3.12, so that when drop Python 3.11 support and
 # lower, this can be updated to `type DataTree = ...`.
-# TensorModel must come before dict so Pydantic tries it first during deserialization.
+# CompressableTensorModel must come before dict so Pydantic tries it first during deserialization.
 DataTree = TypeAliasType(
     "DataTree",
-    list["DataTree"] | TensorModel | dict[str, "DataTree"] | str | float | int | bool | None,
+    list["DataTree"]
+    | CompressableTensorModel
+    | dict[str, "DataTree"]
+    | str
+    | float
+    | int
+    | bool
+    | None,
 )
 """Arbitrary nesting of lists and dicts with typed leaves."""
 
@@ -99,7 +106,7 @@ class CircuitItemModel(BaseModel):
     item_type: Literal["circuit"] = "circuit"
     """The type of quantum program item."""
 
-    circuit_arguments: F64TensorModel
+    circuit_arguments: F64CompressableTensorModel
     """Arguments to the parameters of the circuit.
 
     The last axis is over ``circuit.parameters``. Execution broadcasts over the
@@ -135,7 +142,7 @@ class SamplexItemModel(BaseModel):
     samplex: SamplexModel
     """A JSON-encoded samplex."""
 
-    samplex_arguments: dict[str, bool | int | PauliLindbladMapModel | TensorModel]
+    samplex_arguments: dict[str, bool | int | PauliLindbladMapModel | CompressableTensorModel]
     """Arguments to the samplex."""
 
     shape: list[int]
@@ -273,7 +280,7 @@ class ItemMetadataModel(BaseModel):
 class QuantumProgramResultItemModel(BaseModel):
     """Results for a single quantum program item."""
 
-    results: dict[str, TensorModel]
+    results: dict[str, CompressableTensorModel]
     """A map from results to their tensor values."""
 
     metadata: ItemMetadataModel

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -24,9 +24,9 @@ from typing_extensions import TypeAliasType
 from ibm_quantum_schemas.aliases import Self
 from ibm_quantum_schemas.common import (
     BaseParamsModel,
-    CompressableQpyDataV13ToV17Model,
-    CompressableTensorModel,
-    F64CompressableTensorModel,
+    CompressedQpyDataV13ToV17Model,
+    CompressedTensorModel,
+    F64CompressedTensorModel,
     PauliLindbladMapModel,
     TensorModel,
 )
@@ -40,7 +40,7 @@ DataTree = TypeAliasType(
     "DataTree",
     list["DataTree"]
     | TensorModel
-    | CompressableTensorModel
+    | CompressedTensorModel
     | dict[str, "DataTree"]
     | str
     | float
@@ -108,7 +108,7 @@ class CircuitItemModel(BaseModel):
     item_type: Literal["circuit"] = "circuit"
     """The type of quantum program item."""
 
-    circuit_arguments: F64CompressableTensorModel
+    circuit_arguments: F64CompressedTensorModel
     """Arguments to the parameters of the circuit.
 
     The last axis is over ``circuit.parameters``. Execution broadcasts over the
@@ -144,7 +144,7 @@ class SamplexItemModel(BaseModel):
     samplex: SamplexModel
     """A JSON-encoded samplex."""
 
-    samplex_arguments: dict[str, bool | int | PauliLindbladMapModel | CompressableTensorModel]
+    samplex_arguments: dict[str, bool | int | PauliLindbladMapModel | CompressedTensorModel]
     """Arguments to the samplex."""
 
     shape: list[int]
@@ -170,7 +170,7 @@ class QuantumProgramModel(BaseModel):
     shots: int = Field(ge=1)
     """The number of shots for each individually bound circuit."""
 
-    circuits: CompressableQpyDataV13ToV17Model[QuantumCircuit]
+    circuits: CompressedQpyDataV13ToV17Model[QuantumCircuit]
     """One quantum circuit for every element of ``items``.
 
     These are stored outside of ``items`` to cosituate them inside of one QPY blob.
@@ -282,7 +282,7 @@ class ItemMetadataModel(BaseModel):
 class QuantumProgramResultItemModel(BaseModel):
     """Results for a single quantum program item."""
 
-    results: dict[str, CompressableTensorModel]
+    results: dict[str, CompressedTensorModel]
     """A map from results to their tensor values."""
 
     metadata: ItemMetadataModel

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -24,10 +24,10 @@ from typing_extensions import TypeAliasType
 from ibm_quantum_schemas.aliases import Self
 from ibm_quantum_schemas.common import (
     BaseParamsModel,
+    CompressableQpyDataV13ToV17Model,
     CompressableTensorModel,
     F64CompressableTensorModel,
     PauliLindbladMapModel,
-    QpyDataV13ToV17Model,
 )
 from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 
@@ -168,7 +168,7 @@ class QuantumProgramModel(BaseModel):
     shots: int = Field(ge=1)
     """The number of shots for each individually bound circuit."""
 
-    circuits: QpyDataV13ToV17Model[QuantumCircuit]
+    circuits: CompressableQpyDataV13ToV17Model[QuantumCircuit]
     """One quantum circuit for every element of ``items``.
 
     These are stored outside of ``items`` to cosituate them inside of one QPY blob.

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -21,6 +21,7 @@ from qiskit.qpy import dump
 from samplomatic import ChangeBasis, InjectNoise, Twirl
 
 from ibm_quantum_schemas.common.qpy import (
+    CompressableQpyDataV13ToV17Model,
     QpyDataV13ToV17Model,
     QpyModelV13ToV16,
     QpyModelV13ToV17,
@@ -188,3 +189,67 @@ class TestQpyDataV13ToV17Model:
 
         with pytest.raises(ValueError):
             QpyDataV13ToV17Model.from_python([circuit], qpy_version)
+
+
+class TestCompressableQpyDataV13ToV17Model:
+    """Tests for ``CompressableQpyDataV13ToV17Model``."""
+
+    @pytest.mark.skip_if_qiskit_too_old_for_qpy
+    @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_roundtrip(self, qpy_version, compress):
+        """Test that round trips work correctly."""
+        circuit0 = QuantumCircuit(3)
+        circuit0.h(0)
+        circuit0.cx(0, 1)
+        circuit0.measure_all()
+
+        circuit1 = QuantumCircuit(2)
+        circuit1.h(0)
+        circuit1.measure_all()
+
+        circuits = [circuit0, circuit1]
+
+        encoded = CompressableQpyDataV13ToV17Model.from_python(
+            circuits, qpy_version, compress=compress
+        )
+
+        assert encoded.num_programs == 2
+        assert encoded.qpy_version == qpy_version
+        assert encoded.compressed == compress
+
+        circuits_out = encoded.to_python()
+
+        assert circuits == circuits_out
+
+    @pytest.mark.skip_if_qiskit_too_old_for_qpy
+    @pytest.mark.parametrize("qpy_version", [15, 16, 17])
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_roundtrip_with_annotations(self, qpy_version, compress):
+        """Test that round trips work correctly for circuits with annotated boxes."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+            circuit.cx(1, 2)
+        circuit.measure_all()
+
+        encoded = CompressableQpyDataV13ToV17Model.from_python(
+            [circuit], qpy_version, compress=compress
+        )
+        circuits_out = encoded.to_python()
+
+        assert encoded.compressed == compress
+        assert len(circuits_out) == 1
+        assert circuit == circuits_out[0]
+
+    @pytest.mark.parametrize("qpy_version", [12, 18])
+    def test_unsupported_versions_raise(self, qpy_version):
+        """Test that unsupported versions raise."""
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.measure_all()
+
+        with pytest.raises(ValueError):
+            CompressableQpyDataV13ToV17Model.from_python([circuit], qpy_version)

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -13,6 +13,7 @@
 """Tests for QPY models."""
 
 from io import BytesIO
+from zlib import compress
 
 import pytest
 from pybase64 import b64encode
@@ -21,7 +22,7 @@ from qiskit.qpy import dump
 from samplomatic import ChangeBasis, InjectNoise, Twirl
 
 from ibm_quantum_schemas.common.qpy import (
-    CompressableQpyDataV13ToV17Model,
+    CompressedQpyDataV13ToV17Model,
     QpyDataV13ToV17Model,
     QpyModelV13ToV16,
     QpyModelV13ToV17,
@@ -31,16 +32,20 @@ from ibm_quantum_schemas.common.qpy import (
 
 @pytest.mark.parametrize("qpy_version", [15, 16])
 @pytest.mark.parametrize("num_circuits", [1, 3])
-def test_extract_qpy_info(qpy_version, num_circuits):
+@pytest.mark.parametrize("compressed", [False, True])
+def test_extract_qpy_info(qpy_version, num_circuits, compressed):
     """Test the ``extract_qpy_info`` function."""
     circuit = QuantumCircuit(3)
     circuit.measure_all()
 
     with BytesIO() as bytes_buf:
         dump([circuit] * num_circuits, bytes_buf, version=qpy_version)
-        qpy_str = b64encode(bytes_buf.getvalue()).decode()
+        raw_data = bytes_buf.getvalue()
+        if compressed:
+            raw_data = compress(raw_data)
+        qpy_str = b64encode(raw_data).decode()
 
-    info = extract_qpy_info(qpy_str)
+    info = extract_qpy_info(qpy_str, compressed)
     assert info.qpy_version == qpy_version
     assert info.num_programs == num_circuits
 
@@ -191,13 +196,12 @@ class TestQpyDataV13ToV17Model:
             QpyDataV13ToV17Model.from_python([circuit], qpy_version)
 
 
-class TestCompressableQpyDataV13ToV17Model:
-    """Tests for ``CompressableQpyDataV13ToV17Model``."""
+class TestCompressedQpyDataV13ToV17Model:
+    """Tests for ``CompressedQpyDataV13ToV17Model``."""
 
     @pytest.mark.skip_if_qiskit_too_old_for_qpy
     @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
-    @pytest.mark.parametrize("compress", [True, False])
-    def test_roundtrip(self, qpy_version, compress):
+    def test_roundtrip(self, qpy_version):
         """Test that round trips work correctly."""
         circuit0 = QuantumCircuit(3)
         circuit0.h(0)
@@ -210,13 +214,13 @@ class TestCompressableQpyDataV13ToV17Model:
 
         circuits = [circuit0, circuit1]
 
-        encoded = CompressableQpyDataV13ToV17Model.from_python(
-            circuits, qpy_version, compress=compress
+        encoded = CompressedQpyDataV13ToV17Model.from_python(
+            circuits,
+            qpy_version,
         )
 
         assert encoded.num_programs == 2
         assert encoded.qpy_version == qpy_version
-        assert encoded.compressed == compress
 
         circuits_out = encoded.to_python()
 
@@ -224,8 +228,7 @@ class TestCompressableQpyDataV13ToV17Model:
 
     @pytest.mark.skip_if_qiskit_too_old_for_qpy
     @pytest.mark.parametrize("qpy_version", [15, 16, 17])
-    @pytest.mark.parametrize("compress", [True, False])
-    def test_roundtrip_with_annotations(self, qpy_version, compress):
+    def test_roundtrip_with_annotations(self, qpy_version):
         """Test that round trips work correctly for circuits with annotated boxes."""
         circuit = QuantumCircuit(3)
         circuit.h(0)
@@ -234,12 +237,12 @@ class TestCompressableQpyDataV13ToV17Model:
             circuit.cx(1, 2)
         circuit.measure_all()
 
-        encoded = CompressableQpyDataV13ToV17Model.from_python(
-            [circuit], qpy_version, compress=compress
+        encoded = CompressedQpyDataV13ToV17Model.from_python(
+            [circuit],
+            qpy_version,
         )
         circuits_out = encoded.to_python()
 
-        assert encoded.compressed == compress
         assert len(circuits_out) == 1
         assert circuit == circuits_out[0]
 
@@ -252,4 +255,4 @@ class TestCompressableQpyDataV13ToV17Model:
         circuit.measure_all()
 
         with pytest.raises(ValueError):
-            CompressableQpyDataV13ToV17Model.from_python([circuit], qpy_version)
+            CompressedQpyDataV13ToV17Model.from_python([circuit], qpy_version)

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -16,7 +16,12 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from ibm_quantum_schemas.common.tensor import F64TensorModel, TensorModel
+from ibm_quantum_schemas.common.tensor import (
+    CompressableTensorModel,
+    F64CompressableTensorModel,
+    F64TensorModel,
+    TensorModel,
+)
 
 
 class TestTensorModel:
@@ -56,3 +61,48 @@ class TestF64TensorModel:
 
         with pytest.raises(ValidationError):
             F64TensorModel.from_numpy(array)
+
+
+class TestCompressableTensorModel:
+    """Tests for ``CompressableTensorModel``."""
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.float64, np.bool_, np.complex128])
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_roundtrip(self, dtype, compress):
+        """Test that round trips work correctly."""
+        array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))
+        encoded = CompressableTensorModel.from_numpy(array, compress=compress)
+        array_out = encoded.to_numpy()
+
+        assert encoded.compressed == compress
+        assert np.all(array == array_out)
+        assert array.dtype == array_out.dtype
+
+    def test_raises(self):
+        """Test that it raises."""
+        array = np.array(range(16), dtype=int)
+
+        with pytest.raises(ValueError, match="Unexpected NumPy dtype 'int64'"):
+            CompressableTensorModel.from_numpy(array)
+
+
+class TestF64CompressableTensorModel:
+    """Tests for ``F64CompressableTensorModel``."""
+
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_roundtrip(self, compress):
+        """Test that round trips work correctly."""
+        array = np.array(range(16), dtype=np.float64).reshape((4, 1, 2, 2))
+        encoded = F64CompressableTensorModel.from_numpy(array, compress=compress)
+        array_out = encoded.to_numpy()
+
+        assert encoded.compressed == compress
+        assert np.all(array == array_out)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.bool_])
+    def test_raises(self, dtype):
+        """Test that it raises."""
+        array = np.array(range(16), dtype=dtype)
+
+        with pytest.raises(ValidationError):
+            F64CompressableTensorModel.from_numpy(array)

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -17,8 +17,8 @@ import pytest
 from pydantic import ValidationError
 
 from ibm_quantum_schemas.common.tensor import (
-    CompressableTensorModel,
-    F64CompressableTensorModel,
+    CompressedTensorModel,
+    F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
 )
@@ -63,18 +63,16 @@ class TestF64TensorModel:
             F64TensorModel.from_numpy(array)
 
 
-class TestCompressableTensorModel:
-    """Tests for ``CompressableTensorModel``."""
+class TestCompressedTensorModel:
+    """Tests for ``CompressedTensorModel``."""
 
     @pytest.mark.parametrize("dtype", [np.uint8, np.float64, np.bool_, np.complex128])
-    @pytest.mark.parametrize("compress", [True, False])
-    def test_roundtrip(self, dtype, compress):
+    def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))
-        encoded = CompressableTensorModel.from_numpy(array, compress=compress)
+        encoded = CompressedTensorModel.from_numpy(array)
         array_out = encoded.to_numpy()
 
-        assert encoded.compressed == compress
         assert np.all(array == array_out)
         assert array.dtype == array_out.dtype
 
@@ -83,20 +81,18 @@ class TestCompressableTensorModel:
         array = np.array(range(16), dtype=int)
 
         with pytest.raises(ValueError, match="Unexpected NumPy dtype 'int64'"):
-            CompressableTensorModel.from_numpy(array)
+            CompressedTensorModel.from_numpy(array)
 
 
-class TestF64CompressableTensorModel:
-    """Tests for ``F64CompressableTensorModel``."""
+class TestF64CompressedTensorModel:
+    """Tests for ``F64CompressedTensorModel``."""
 
-    @pytest.mark.parametrize("compress", [True, False])
-    def test_roundtrip(self, compress):
+    def test_roundtrip(self):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=np.float64).reshape((4, 1, 2, 2))
-        encoded = F64CompressableTensorModel.from_numpy(array, compress=compress)
+        encoded = F64CompressedTensorModel.from_numpy(array)
         array_out = encoded.to_numpy()
 
-        assert encoded.compressed == compress
         assert np.all(array == array_out)
 
     @pytest.mark.parametrize("dtype", [np.uint8, np.bool_])
@@ -105,4 +101,4 @@ class TestF64CompressableTensorModel:
         array = np.array(range(16), dtype=dtype)
 
         with pytest.raises(ValidationError):
-            F64CompressableTensorModel.from_numpy(array)
+            F64CompressedTensorModel.from_numpy(array)

--- a/test/executor/version_2_0_dev/test_models.py
+++ b/test/executor/version_2_0_dev/test_models.py
@@ -21,7 +21,7 @@ from samplomatic import Twirl, build
 
 from ibm_quantum_schemas.common.qpy import QpyDataV13ToV17Model as QpyDataModel
 from ibm_quantum_schemas.common.samplex import SamplexModelSSV1ToSSV4 as SamplexModel
-from ibm_quantum_schemas.common.tensor import F64TensorModel, TensorModel
+from ibm_quantum_schemas.common.tensor import CompressableTensorModel, F64CompressableTensorModel
 from ibm_quantum_schemas.executor.version_2_0_dev import (
     ChunkPart,
     ChunkSpan,
@@ -43,7 +43,8 @@ def _minimal_quantum_program(**kwargs) -> QuantumProgramModel:
     """Create a QuantumProgramModel with one minimal circuit item."""
     circuit = QuantumCircuit(1)
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)), shape=()
+        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
+        shape=(),
     )
     return QuantumProgramModel(
         shots=100,
@@ -70,7 +71,9 @@ def test_initialization_params_model(qpy_version, ssv, chunk_size):
     circuit0.cx(0, 1)
     circuit0.measure_all()
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64)),
+        circuit_arguments=F64CompressableTensorModel.from_numpy(
+            np.array([0.1, 0.2, 0.3], dtype=np.float64)
+        ),
         chunk_size=chunk_size,
         shape=[],
     )
@@ -87,7 +90,9 @@ def test_initialization_params_model(qpy_version, ssv, chunk_size):
     samplex_item = SamplexItemModel(
         samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
-            "parameter_values": TensorModel.from_numpy(np.array([0.1, 0.2, 0.3], dtype=np.float64))
+            "parameter_values": CompressableTensorModel.from_numpy(
+                np.array([0.1, 0.2, 0.3], dtype=np.float64)
+            )
         },
         shape=(200, 300),
         chunk_size=chunk_size,
@@ -124,8 +129,8 @@ def test_initialization_results_model():
     """Test initialization for ``QuantumProgramResultModel`` and related models."""
     result_item = QuantumProgramResultItemModel(
         results={
-            "alpha": TensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
-            "beta": TensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
+            "alpha": CompressableTensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
+            "beta": CompressableTensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
         },
         metadata=ItemMetadataModel(),
     )
@@ -154,7 +159,7 @@ def test_chunk_size_validation(ssv, qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
+        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
         shape=[],
     )
@@ -163,7 +168,7 @@ def test_chunk_size_validation(ssv, qpy_version):
     samplex_item = SamplexItemModel(
         samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
-            "parameter_values": TensorModel.from_numpy(np.array([], dtype=np.float64))
+            "parameter_values": CompressableTensorModel.from_numpy(np.array([], dtype=np.float64))
         },
         shape=(),
         chunk_size="auto",
@@ -183,7 +188,7 @@ def test_meas_level(meas_level):
     circuit = QuantumCircuit(3)
     circuit.measure_all()
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64TensorModel.from_numpy(np.array([], dtype=np.float64)),
+        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
         shape=[],
     )
 
@@ -262,7 +267,7 @@ def test_result_item_with_metadata():
 
     result_item = QuantumProgramResultItemModel(
         results={
-            "counts": TensorModel.from_numpy(np.array([100, 200], dtype=np.float64)),
+            "counts": CompressableTensorModel.from_numpy(np.array([100, 200], dtype=np.float64)),
         },
         metadata=item_metadata,
     )
@@ -280,7 +285,7 @@ def test_semantic_role(role):
 
 def test_passthrough_data_leaf_types():
     """Test that all leaf types are accepted."""
-    tensor = TensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
 
     # Test each leaf type individually
     for passthrough_data in [tensor, "hello", 3.14, 42, True, False, None]:
@@ -303,8 +308,8 @@ def test_passthrough_data_nested_dict():
 
 
 def test_passthrough_data_mixed_nesting():
-    """Test mixed lists and dicts with TensorModel leaves."""
-    tensor = TensorModel.from_numpy(np.array([1.1, 2.0, 3.0], dtype=np.float64))
+    """Test mixed lists and dicts with CompressableTensorModel leaves."""
+    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0, 3.0], dtype=np.float64))
     passthrough_data = {
         "tensors": [tensor, tensor],
         "metadata": {"name": "test", "count": 42},
@@ -325,7 +330,7 @@ def test_result_with_semantic_role(role):
 
 def test_passthrough_data_on_result_model():
     """Test passthrough_data on QuantumProgramResultModel."""
-    tensor = TensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
     passthrough_data = {"result_tensor": tensor, "info": ["a", "b", 3]}
 
     result = QuantumProgramResultModel(
@@ -336,7 +341,7 @@ def test_passthrough_data_on_result_model():
 
 def test_passthrough_data_serialization_roundtrip():
     """Test that DataTree survives JSON serialization roundtrip."""
-    tensor = TensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
     passthrough_data = {"tensor": tensor, "nested": [1, {"inner": "value"}]}
     program = _minimal_quantum_program(passthrough_data=passthrough_data)
 

--- a/test/executor/version_2_0_dev/test_models.py
+++ b/test/executor/version_2_0_dev/test_models.py
@@ -19,7 +19,7 @@ import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 from samplomatic import Twirl, build
 
-from ibm_quantum_schemas.common.qpy import QpyDataV13ToV17Model as QpyDataModel
+from ibm_quantum_schemas.common.qpy import CompressableQpyDataV13ToV17Model as QpyDataModel
 from ibm_quantum_schemas.common.samplex import SamplexModelSSV1ToSSV4 as SamplexModel
 from ibm_quantum_schemas.common.tensor import CompressableTensorModel, F64CompressableTensorModel
 from ibm_quantum_schemas.executor.version_2_0_dev import (

--- a/test/executor/version_2_0_dev/test_models.py
+++ b/test/executor/version_2_0_dev/test_models.py
@@ -19,9 +19,9 @@ import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 from samplomatic import Twirl, build
 
-from ibm_quantum_schemas.common.qpy import CompressableQpyDataV13ToV17Model as QpyDataModel
+from ibm_quantum_schemas.common.qpy import CompressedQpyDataV13ToV17Model as QpyDataModel
 from ibm_quantum_schemas.common.samplex import SamplexModelSSV1ToSSV4 as SamplexModel
-from ibm_quantum_schemas.common.tensor import CompressableTensorModel, F64CompressableTensorModel
+from ibm_quantum_schemas.common.tensor import CompressedTensorModel, F64CompressedTensorModel
 from ibm_quantum_schemas.executor.version_2_0_dev import (
     ChunkPart,
     ChunkSpan,
@@ -43,7 +43,7 @@ def _minimal_quantum_program(**kwargs) -> QuantumProgramModel:
     """Create a QuantumProgramModel with one minimal circuit item."""
     circuit = QuantumCircuit(1)
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
+        circuit_arguments=F64CompressedTensorModel.from_numpy(np.array([], dtype=np.float64)),
         shape=(),
     )
     return QuantumProgramModel(
@@ -71,7 +71,7 @@ def test_initialization_params_model(qpy_version, ssv, chunk_size):
     circuit0.cx(0, 1)
     circuit0.measure_all()
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64CompressableTensorModel.from_numpy(
+        circuit_arguments=F64CompressedTensorModel.from_numpy(
             np.array([0.1, 0.2, 0.3], dtype=np.float64)
         ),
         chunk_size=chunk_size,
@@ -90,7 +90,7 @@ def test_initialization_params_model(qpy_version, ssv, chunk_size):
     samplex_item = SamplexItemModel(
         samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
-            "parameter_values": CompressableTensorModel.from_numpy(
+            "parameter_values": CompressedTensorModel.from_numpy(
                 np.array([0.1, 0.2, 0.3], dtype=np.float64)
             )
         },
@@ -129,8 +129,8 @@ def test_initialization_results_model():
     """Test initialization for ``QuantumProgramResultModel`` and related models."""
     result_item = QuantumProgramResultItemModel(
         results={
-            "alpha": CompressableTensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
-            "beta": CompressableTensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
+            "alpha": CompressedTensorModel.from_numpy(np.array([0.1, 0.2], dtype=np.float64)),
+            "beta": CompressedTensorModel.from_numpy(np.array([0.3, 0.4, 0.5], dtype=np.float64)),
         },
         metadata=ItemMetadataModel(),
     )
@@ -159,7 +159,7 @@ def test_chunk_size_validation(ssv, qpy_version):
     """Test initialization for ``ParamsModel`` and related models."""
     circuit = QuantumCircuit(3)
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
+        circuit_arguments=F64CompressedTensorModel.from_numpy(np.array([], dtype=np.float64)),
         chunk_size=2,
         shape=[],
     )
@@ -168,7 +168,7 @@ def test_chunk_size_validation(ssv, qpy_version):
     samplex_item = SamplexItemModel(
         samplex=SamplexModel.from_samplex(samplex, ssv=ssv),
         samplex_arguments={
-            "parameter_values": CompressableTensorModel.from_numpy(np.array([], dtype=np.float64))
+            "parameter_values": CompressedTensorModel.from_numpy(np.array([], dtype=np.float64))
         },
         shape=(),
         chunk_size="auto",
@@ -188,7 +188,7 @@ def test_meas_level(meas_level):
     circuit = QuantumCircuit(3)
     circuit.measure_all()
     circuit_item = CircuitItemModel(
-        circuit_arguments=F64CompressableTensorModel.from_numpy(np.array([], dtype=np.float64)),
+        circuit_arguments=F64CompressedTensorModel.from_numpy(np.array([], dtype=np.float64)),
         shape=[],
     )
 
@@ -267,7 +267,7 @@ def test_result_item_with_metadata():
 
     result_item = QuantumProgramResultItemModel(
         results={
-            "counts": CompressableTensorModel.from_numpy(np.array([100, 200], dtype=np.float64)),
+            "counts": CompressedTensorModel.from_numpy(np.array([100, 200], dtype=np.float64)),
         },
         metadata=item_metadata,
     )
@@ -285,7 +285,7 @@ def test_semantic_role(role):
 
 def test_passthrough_data_leaf_types():
     """Test that all leaf types are accepted."""
-    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressedTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
 
     # Test each leaf type individually
     for passthrough_data in [tensor, "hello", 3.14, 42, True, False, None]:
@@ -309,7 +309,7 @@ def test_passthrough_data_nested_dict():
 
 def test_passthrough_data_mixed_nesting():
     """Test mixed lists and dicts with CompressableTensorModel leaves."""
-    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0, 3.0], dtype=np.float64))
+    tensor = CompressedTensorModel.from_numpy(np.array([1.1, 2.0, 3.0], dtype=np.float64))
     passthrough_data = {
         "tensors": [tensor, tensor],
         "metadata": {"name": "test", "count": 42},
@@ -330,7 +330,7 @@ def test_result_with_semantic_role(role):
 
 def test_passthrough_data_on_result_model():
     """Test passthrough_data on QuantumProgramResultModel."""
-    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressedTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
     passthrough_data = {"result_tensor": tensor, "info": ["a", "b", 3]}
 
     result = QuantumProgramResultModel(
@@ -341,7 +341,7 @@ def test_passthrough_data_on_result_model():
 
 def test_passthrough_data_serialization_roundtrip():
     """Test that DataTree survives JSON serialization roundtrip."""
-    tensor = CompressableTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
+    tensor = CompressedTensorModel.from_numpy(np.array([1.1, 2.0], dtype=np.float64))
     passthrough_data = {"tensor": tensor, "nested": [1, {"inner": "value"}]}
     program = _minimal_quantum_program(passthrough_data=passthrough_data)
 


### PR DESCRIPTION
### Summary
Adding the option to compress arrays in the Executor v2.0 schema. This includes introducing the models: `CompressableQpyDataModel`, `CompressableQpyDataV13ToV17Model`, `CompressableTensorModel`, and `F64CompressableTensorModel`. 

This PR closes #159.
