### PR TITLE
Additional dtype support for CompressedTensorModel

### DIFF
--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -41,7 +41,10 @@ Classes
    TensorModel
    F64TensorModel
    CompressedTensorModel
+   BoolCompressedTensorModel
+   C128CompressedTensorModel
    F64CompressedTensorModel
+   U8CompressedTensorModel
 """
 
 from ibm_quantum_schemas.common.base_params import BaseParamsModel
@@ -63,8 +66,11 @@ from ibm_quantum_schemas.common.samplex import (
     SamplexModelSSV1ToSSV4,
 )
 from ibm_quantum_schemas.common.tensor import (
+    BoolCompressedTensorModel,
+    C128CompressedTensorModel,
     CompressedTensorModel,
     F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
+    U8CompressedTensorModel,
 )

--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -41,10 +41,7 @@ Classes
    TensorModel
    F64TensorModel
    CompressedTensorModel
-   BoolCompressedTensorModel
-   C128CompressedTensorModel
    F64CompressedTensorModel
-   U8CompressedTensorModel
 """
 
 from ibm_quantum_schemas.common.base_params import BaseParamsModel
@@ -66,11 +63,8 @@ from ibm_quantum_schemas.common.samplex import (
     SamplexModelSSV1ToSSV4,
 )
 from ibm_quantum_schemas.common.tensor import (
-    BoolCompressedTensorModel,
-    C128CompressedTensorModel,
     CompressedTensorModel,
     F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
-    U8CompressedTensorModel,
 )

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -24,15 +24,19 @@ SupportedDtypes: TypeAlias = Literal["f64", "bool", "u8", "c128"]
 """The data types supported by :class:`~TensorModel`."""
 
 SupportedDtypesExtended: TypeAlias = Literal[
-    "f16", "f32", "f64", "bool", "u8", "u16", "u32", "u64", "c64", "c128"
+    "f16", "f32", "f64", "bool", "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "c64", "c128"
 ]
 """The data types supported by :class:`~CompressedTensorModel`."""
 
-_SUPPORTED_DTYPE_MAP: dict[np.dtype, SupportedDtypesExtended] = {
+SUPPORTED_DTYPE_EXTENDED_MAP: dict[np.dtype, SupportedDtypesExtended] = {
     np.dtype(np.bool): "bool",
     np.dtype(np.float16): "f16",
     np.dtype(np.float32): "f32",
     np.dtype(np.float64): "f64",
+    np.dtype(np.int8): "i8",
+    np.dtype(np.int16): "i16",
+    np.dtype(np.int32): "i32",
+    np.dtype(np.int64): "i64",
     np.dtype(np.uint8): "u8",
     np.dtype(np.uint16): "u16",
     np.dtype(np.uint32): "u32",
@@ -40,6 +44,7 @@ _SUPPORTED_DTYPE_MAP: dict[np.dtype, SupportedDtypesExtended] = {
     np.dtype(np.complex64): "c64",
     np.dtype(np.complex128): "c128",
 }
+"""A map from NumPy dtypes to :type:`~SupportedDtypesExtended`."""
 
 
 class TensorModel(BaseModel):
@@ -133,6 +138,10 @@ class CompressedTensorModel(TensorModel):
         "f16": 2,
         "f32": 4,
         "f64": 8,
+        "i8": 1,
+        "i16": 2,
+        "i32": 4,
+        "i64": 8,
         "u8": 1,
         "u16": 2,
         "u32": 4,
@@ -141,6 +150,7 @@ class CompressedTensorModel(TensorModel):
         "c64": 8,
         "c128": 16,
     }
+    """A lookup table for the element sizes of :type:`~SupportedDtypesExtended`."""
 
     dtype: SupportedDtypesExtended
     """The data type of the tensor."""
@@ -149,7 +159,7 @@ class CompressedTensorModel(TensorModel):
     def from_numpy(cls, array: np.ndarray):
         """Instantiate from a NumPy array."""
         array_dtype = array.dtype
-        dtype = _SUPPORTED_DTYPE_MAP.get(array_dtype)
+        dtype = SUPPORTED_DTYPE_EXTENDED_MAP.get(array_dtype)
         if dtype is None:
             raise ValueError(
                 f"Unexpected NumPy dtype '{array_dtype}', one of "

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -19,71 +19,27 @@ from typing import Literal, TypeAlias, get_args
 import numpy as np
 import pybase64
 from pydantic import BaseModel, model_validator
-from typing_extensions import Buffer
 
 SupportedDtypes: TypeAlias = Literal["f64", "bool", "u8", "c128"]
 """The data types supported by :class:`~TensorModel`."""
 
+SupportedDtypesExtended: TypeAlias = Literal[
+    "f16", "f32", "f64", "bool", "u8", "u16", "u32", "u64", "c64", "c128"
+]
+"""The data types supported by :class:`~CompressedTensorModel`."""
 
-def _from_buffer(raw: Buffer, dtype: SupportedDtypes, shape: tuple[int, ...]) -> np.ndarray:
-    """Convert a buffer of bytes into a NumPy array of the specified dtype and shape.
-
-    Args:
-        raw: The buffer of bytes to convert.
-        dtype: The data type of the resulting NumPy array.
-        shape: The shape of the resulting NumPy array.
-
-    Returns:
-        A NumPy array of the specified dtype and shape.
-
-    Raises:
-        ValueError: If the dtype is not supported.
-    """
-    if dtype == "f64":
-        return np.frombuffer(raw, dtype="<f8").reshape(shape)
-    elif dtype == "bool":
-        # Total number of elements from shape
-        total = np.prod(shape, dtype=int)
-        unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
-        return unpacked.astype(bool).reshape(shape)
-    elif dtype == "u8":
-        return np.frombuffer(raw, dtype="<u1").reshape(shape)
-    elif dtype == "c128":
-        return np.frombuffer(raw, dtype="<c16").reshape(shape)
-
-    raise ValueError(f"dtype {dtype} not understood.")
-
-
-def _get_dtype_and_bytes(array: np.ndarray) -> tuple[SupportedDtypes, bytes]:
-    """Get the dtype string and bytes representation of a NumPy array.
-
-    Args:
-        array: The NumPy array to convert.
-
-    Returns:
-        A tuple containing the dtype string and the bytes representation of the array.
-
-    Raises:
-        ValueError: If the dtype of the array is not supported.
-    """
-    if array.dtype == np.dtype(np.float64):
-        dtype = "f64"
-        byte_data = array.astype("<f8").tobytes()
-    elif array.dtype == np.dtype(np.bool_):
-        dtype = "bool"
-        byte_data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
-    elif array.dtype == np.dtype(np.uint8):
-        dtype = "u8"
-        byte_data = array.astype("<u1").tobytes()
-    elif array.dtype == np.dtype(np.complex128):
-        dtype = "c128"
-        byte_data = array.astype("<c16").tobytes()
-    else:
-        raise ValueError(
-            f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
-            "expected."
-        )
-    return dtype, byte_data
+_SUPPORTED_DTYPE_MAP: dict[np.dtype, SupportedDtypesExtended] = {
+    np.dtype(np.bool): "bool",
+    np.dtype(np.float16): "f16",
+    np.dtype(np.float32): "f32",
+    np.dtype(np.float64): "f64",
+    np.dtype(np.uint8): "u8",
+    np.dtype(np.uint16): "u16",
+    np.dtype(np.uint32): "u32",
+    np.dtype(np.uint64): "u64",
+    np.dtype(np.complex64): "c64",
+    np.dtype(np.complex128): "c128",
+}
 
 
 class TensorModel(BaseModel):
@@ -107,15 +63,45 @@ class TensorModel(BaseModel):
     @classmethod
     def from_numpy(cls, array: np.ndarray):
         """Instantiate from a NumPy array."""
-        dtype, data = _get_dtype_and_bytes(array)
-        encoded_data = pybase64.b64encode(data).decode("utf-8")
-        return cls(data=encoded_data, shape=array.shape, dtype=dtype)
+        if array.dtype == np.dtype(np.float64):
+            dtype = "f64"
+            data = pybase64.b64encode(array.astype("<f8").tobytes())
+        elif array.dtype == np.dtype(np.bool_):
+            dtype = "bool"
+            packed = np.packbits(array.astype(np.uint8), bitorder="little")
+            data = pybase64.b64encode(packed.tobytes())
+        elif array.dtype == np.dtype(np.uint8):
+            dtype = "u8"
+            data = pybase64.b64encode(array.astype("<u1").tobytes())
+        elif array.dtype == np.dtype(np.complex128):
+            dtype = "c128"
+            data = pybase64.b64encode(array.astype("<c16").tobytes())
+        else:
+            raise ValueError(
+                f"Unexpected NumPy dtype '{array.dtype}', one of {get_args(SupportedDtypes)} "
+                "expected."
+            )
+
+        return cls(data=data, shape=array.shape, dtype=dtype)
 
     def to_numpy(self) -> np.ndarray:
         """Convert to a NumPy Array."""
         shape = tuple(self.shape)
         raw = pybase64.b64decode(self.data)
-        return _from_buffer(raw, self.dtype, shape)
+
+        if self.dtype == "f64":
+            return np.frombuffer(raw, dtype="<f8").reshape(shape)
+        elif self.dtype == "bool":
+            # Total number of elements from shape
+            total = np.prod(shape, dtype=int)
+            unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
+            return unpacked.astype(bool).reshape(shape)
+        elif self.dtype == "u8":
+            return np.frombuffer(raw, dtype="<u1").reshape(shape)
+        elif self.dtype == "c128":
+            return np.frombuffer(raw, dtype="<c16").reshape(shape)
+
+        raise ValueError(f"dtype {self.dtype} not understood.")
 
     @model_validator(mode="after")
     def check_sizes(self):
@@ -143,10 +129,36 @@ class F64TensorModel(TensorModel):
 class CompressedTensorModel(TensorModel):
     """Model of compressed tensor data."""
 
+    _ELEM_SIZE_LOOKUP = {
+        "f16": 2,
+        "f32": 4,
+        "f64": 8,
+        "u8": 1,
+        "u16": 2,
+        "u32": 4,
+        "u64": 8,
+        "bool": 0.125,
+        "c64": 8,
+        "c128": 16,
+    }
+
+    dtype: SupportedDtypesExtended
+    """The data type of the tensor."""
+
     @classmethod
     def from_numpy(cls, array: np.ndarray):
         """Instantiate from a NumPy array."""
-        dtype, data = _get_dtype_and_bytes(array)
+        array_dtype = array.dtype
+        dtype = _SUPPORTED_DTYPE_MAP.get(array_dtype)
+        if dtype is None:
+            raise ValueError(
+                f"Unexpected NumPy dtype '{array_dtype}', one of "
+                f"{get_args(SupportedDtypesExtended)}  expected."
+            )
+        if array_dtype == np.dtype(np.bool_):
+            data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
+        else:
+            data = array.astype(f"<{array_dtype.str[1:]}").tobytes()
         encoded_data = pybase64.b64encode(zlib.compress(data)).decode("utf-8")
         return cls(data=encoded_data, shape=array.shape, dtype=dtype)
 
@@ -154,7 +166,17 @@ class CompressedTensorModel(TensorModel):
         """Convert to a NumPy Array."""
         shape = tuple(self.shape)
         raw = zlib.decompress(pybase64.b64decode(self.data))
-        return _from_buffer(raw, self.dtype, shape)
+        if (dtype := self.dtype) not in get_args(SupportedDtypesExtended):
+            raise ValueError(f"dtype {dtype} not understood.")
+
+        if dtype == "bool":
+            # Total number of elements from shape
+            total = np.prod(shape, dtype=int)
+            unpacked = np.unpackbits(np.frombuffer(raw, dtype=np.uint8), bitorder="little")[:total]
+            return unpacked.astype(bool).reshape(shape)
+
+        dkind, dsize = dtype[0], self._ELEM_SIZE_LOOKUP[dtype]
+        return np.frombuffer(raw, dtype=f"<{dkind}{dsize}").reshape(shape)
 
     @model_validator(mode="after")
     def check_sizes(self):

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -191,25 +191,7 @@ class CompressedTensorModel(TensorModel):
         return self
 
 
-class BoolCompressedTensorModel(CompressedTensorModel):
-    """Model of compressed tensor data specialized to bool."""
-
-    dtype: Literal["bool"] = "bool"
-
-
-class C128CompressedTensorModel(CompressedTensorModel):
-    """Model of compressed tensor data specialized to c128."""
-
-    dtype: Literal["c128"] = "c128"
-
-
 class F64CompressedTensorModel(CompressedTensorModel):
     """Model of compressed tensor data specialized to f64."""
 
     dtype: Literal["f64"] = "f64"
-
-
-class U8CompressedTensorModel(CompressedTensorModel):
-    """Model of compressed tensor data specialized to u8."""
-
-    dtype: Literal["u8"] = "u8"

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -169,7 +169,25 @@ class CompressedTensorModel(TensorModel):
         return self
 
 
+class BoolCompressedTensorModel(CompressedTensorModel):
+    """Model of compressed tensor data specialized to bool."""
+
+    dtype: Literal["bool"] = "bool"
+
+
+class C128CompressedTensorModel(CompressedTensorModel):
+    """Model of compressed tensor data specialized to c128."""
+
+    dtype: Literal["c128"] = "c128"
+
+
 class F64CompressedTensorModel(CompressedTensorModel):
     """Model of compressed tensor data specialized to f64."""
 
     dtype: Literal["f64"] = "f64"
+
+
+class U8CompressedTensorModel(CompressedTensorModel):
+    """Model of compressed tensor data specialized to u8."""
+
+    dtype: Literal["u8"] = "u8"

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -158,7 +158,7 @@ class CompressedTensorModel(TensorModel):
         if array_dtype == np.dtype(np.bool_):
             data = np.packbits(array.astype(np.uint8), bitorder="little").tobytes()
         else:
-            data = array.astype(f"<{array_dtype.str[1:]}").tobytes()
+            data = array.astype(f"<{array_dtype.kind}{array_dtype.itemsize}").tobytes()
         encoded_data = pybase64.b64encode(zlib.compress(data)).decode("utf-8")
         return cls(data=encoded_data, shape=array.shape, dtype=dtype)
 

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -17,10 +17,13 @@ import pytest
 from pydantic import ValidationError
 
 from ibm_quantum_schemas.common.tensor import (
+    BoolCompressedTensorModel,
+    C128CompressedTensorModel,
     CompressedTensorModel,
     F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
+    U8CompressedTensorModel,
 )
 
 
@@ -84,6 +87,46 @@ class TestCompressedTensorModel:
             CompressedTensorModel.from_numpy(array)
 
 
+class TestBoolCompressedTensorModel:
+    """Tests for ``TestBoolCompressedTensorModel``."""
+
+    def test_roundtrip(self):
+        """Test that round trips work correctly."""
+        array = np.array(range(16), dtype=np.bool_).reshape((4, 1, 2, 2))
+        encoded = BoolCompressedTensorModel.from_numpy(array)
+        array_out = encoded.to_numpy()
+
+        assert np.all(array == array_out)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.complex128])
+    def test_raises(self, dtype):
+        """Test that it raises."""
+        array = np.array(range(16), dtype=dtype)
+
+        with pytest.raises(ValidationError):
+            BoolCompressedTensorModel.from_numpy(array)
+
+
+class TestC128CompressedTensorModel:
+    """Tests for ``TestC128CompressedTensorModel``."""
+
+    def test_roundtrip(self):
+        """Test that round trips work correctly."""
+        array = np.array(range(16), dtype=np.complex128).reshape((4, 1, 2, 2))
+        encoded = C128CompressedTensorModel.from_numpy(array)
+        array_out = encoded.to_numpy()
+
+        assert np.all(array == array_out)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.bool_])
+    def test_raises(self, dtype):
+        """Test that it raises."""
+        array = np.array(range(16), dtype=dtype)
+
+        with pytest.raises(ValidationError):
+            C128CompressedTensorModel.from_numpy(array)
+
+
 class TestF64CompressedTensorModel:
     """Tests for ``F64CompressedTensorModel``."""
 
@@ -102,3 +145,23 @@ class TestF64CompressedTensorModel:
 
         with pytest.raises(ValidationError):
             F64CompressedTensorModel.from_numpy(array)
+
+
+class TestU8CompressedTensorModel:
+    """Tests for ``TestU8CompressedTensorModel``."""
+
+    def test_roundtrip(self):
+        """Test that round trips work correctly."""
+        array = np.array(range(16), dtype=np.uint8).reshape((4, 1, 2, 2))
+        encoded = U8CompressedTensorModel.from_numpy(array)
+        array_out = encoded.to_numpy()
+
+        assert np.all(array == array_out)
+
+    @pytest.mark.parametrize("dtype", [np.float64, np.bool_])
+    def test_raises(self, dtype):
+        """Test that it raises."""
+        array = np.array(range(16), dtype=dtype)
+
+        with pytest.raises(ValidationError):
+            U8CompressedTensorModel.from_numpy(array)

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -68,17 +68,7 @@ class TestCompressedTensorModel:
 
     @pytest.mark.parametrize(
         "dtype",
-        [
-            np.uint8,
-            np.uint16,
-            np.uint32,
-            np.uint64,
-            np.float32,
-            np.float64,
-            np.bool_,
-            np.complex64,
-            np.complex128,
-        ],
+        _SUPPORTED_DTYPE_MAP.keys()
     )
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -23,24 +23,11 @@ from ibm_quantum_schemas.common.tensor import (
     TensorModel,
 )
 
-supported_dtypes = [np.uint8, np.float64, np.bool_, np.complex128]
-supported_dtypes_extended = [
-    np.uint8,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-    np.float32,
-    np.float64,
-    np.bool_,
-    np.complex64,
-    np.complex128,
-]
-
 
 class TestTensorModel:
     """Tests for ``TensorModel``."""
 
-    @pytest.mark.parametrize("dtype", supported_dtypes)
+    @pytest.mark.parametrize("dtype", [np.uint8, np.float64, np.bool_, np.complex128])
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))
@@ -79,7 +66,20 @@ class TestF64TensorModel:
 class TestCompressedTensorModel:
     """Tests for ``CompressedTensorModel``."""
 
-    @pytest.mark.parametrize("dtype", supported_dtypes_extended)
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.float32,
+            np.float64,
+            np.bool_,
+            np.complex64,
+            np.complex128,
+        ],
+    )
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import ValidationError
 
 from ibm_quantum_schemas.common.tensor import (
+    SUPPORTED_DTYPE_EXTENDED_MAP,
     CompressedTensorModel,
     F64CompressedTensorModel,
     F64TensorModel,
@@ -66,10 +67,7 @@ class TestF64TensorModel:
 class TestCompressedTensorModel:
     """Tests for ``CompressedTensorModel``."""
 
-    @pytest.mark.parametrize(
-        "dtype",
-        _SUPPORTED_DTYPE_MAP.keys()
-    )
+    @pytest.mark.parametrize("dtype", SUPPORTED_DTYPE_EXTENDED_MAP.keys())
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))
@@ -81,9 +79,9 @@ class TestCompressedTensorModel:
 
     def test_raises(self):
         """Test that it raises."""
-        array = np.array(range(16), dtype=int)
+        array = np.array(range(16), dtype=str)
 
-        with pytest.raises(ValueError, match="Unexpected NumPy dtype 'int64'"):
+        with pytest.raises(ValueError, match="Unexpected NumPy dtype"):
             CompressedTensorModel.from_numpy(array)
 
     def test_bool_array(self):

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -26,11 +26,24 @@ from ibm_quantum_schemas.common.tensor import (
     U8CompressedTensorModel,
 )
 
+supported_dtypes = [np.uint8, np.float64, np.bool_, np.complex128]
+supported_dtypes_extended = [
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float32,
+    np.float64,
+    np.bool_,
+    np.complex64,
+    np.complex128,
+]
+
 
 class TestTensorModel:
     """Tests for ``TensorModel``."""
 
-    @pytest.mark.parametrize("dtype", [np.uint8, np.float64, np.bool_, np.complex128])
+    @pytest.mark.parametrize("dtype", supported_dtypes)
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))
@@ -69,7 +82,7 @@ class TestF64TensorModel:
 class TestCompressedTensorModel:
     """Tests for ``CompressedTensorModel``."""
 
-    @pytest.mark.parametrize("dtype", [np.uint8, np.float64, np.bool_, np.complex128])
+    @pytest.mark.parametrize("dtype", supported_dtypes_extended)
     def test_roundtrip(self, dtype):
         """Test that round trips work correctly."""
         array = np.array(range(16), dtype=dtype).reshape((4, 1, 2, 2))

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -17,13 +17,10 @@ import pytest
 from pydantic import ValidationError
 
 from ibm_quantum_schemas.common.tensor import (
-    BoolCompressedTensorModel,
-    C128CompressedTensorModel,
     CompressedTensorModel,
     F64CompressedTensorModel,
     F64TensorModel,
     TensorModel,
-    U8CompressedTensorModel,
 )
 
 supported_dtypes = [np.uint8, np.float64, np.bool_, np.complex128]
@@ -100,46 +97,6 @@ class TestCompressedTensorModel:
             CompressedTensorModel.from_numpy(array)
 
 
-class TestBoolCompressedTensorModel:
-    """Tests for ``TestBoolCompressedTensorModel``."""
-
-    def test_roundtrip(self):
-        """Test that round trips work correctly."""
-        array = np.array(range(16), dtype=np.bool_).reshape((4, 1, 2, 2))
-        encoded = BoolCompressedTensorModel.from_numpy(array)
-        array_out = encoded.to_numpy()
-
-        assert np.all(array == array_out)
-
-    @pytest.mark.parametrize("dtype", [np.uint8, np.complex128])
-    def test_raises(self, dtype):
-        """Test that it raises."""
-        array = np.array(range(16), dtype=dtype)
-
-        with pytest.raises(ValidationError):
-            BoolCompressedTensorModel.from_numpy(array)
-
-
-class TestC128CompressedTensorModel:
-    """Tests for ``TestC128CompressedTensorModel``."""
-
-    def test_roundtrip(self):
-        """Test that round trips work correctly."""
-        array = np.array(range(16), dtype=np.complex128).reshape((4, 1, 2, 2))
-        encoded = C128CompressedTensorModel.from_numpy(array)
-        array_out = encoded.to_numpy()
-
-        assert np.all(array == array_out)
-
-    @pytest.mark.parametrize("dtype", [np.uint8, np.bool_])
-    def test_raises(self, dtype):
-        """Test that it raises."""
-        array = np.array(range(16), dtype=dtype)
-
-        with pytest.raises(ValidationError):
-            C128CompressedTensorModel.from_numpy(array)
-
-
 class TestF64CompressedTensorModel:
     """Tests for ``F64CompressedTensorModel``."""
 
@@ -158,23 +115,3 @@ class TestF64CompressedTensorModel:
 
         with pytest.raises(ValidationError):
             F64CompressedTensorModel.from_numpy(array)
-
-
-class TestU8CompressedTensorModel:
-    """Tests for ``TestU8CompressedTensorModel``."""
-
-    def test_roundtrip(self):
-        """Test that round trips work correctly."""
-        array = np.array(range(16), dtype=np.uint8).reshape((4, 1, 2, 2))
-        encoded = U8CompressedTensorModel.from_numpy(array)
-        array_out = encoded.to_numpy()
-
-        assert np.all(array == array_out)
-
-    @pytest.mark.parametrize("dtype", [np.float64, np.bool_])
-    def test_raises(self, dtype):
-        """Test that it raises."""
-        array = np.array(range(16), dtype=dtype)
-
-        with pytest.raises(ValidationError):
-            U8CompressedTensorModel.from_numpy(array)


### PR DESCRIPTION
### Summary
`TensorModel` and `CompressedTensorModel` currently only support a very restricted range of dtypes. Here we extend the supported dtypes of `CompressedTensorModel` to include all basic NumPy dtypes:

```
bool
uint8, uint16, uint32, uint64
int8, int16, int32, int64
float16, float32, float64
complex64, complex128
```

### Details and comments
Closes #171 
