### PR TITLE
Bugfix `CompressedTensorModel.check_sizes` for `bool` arrays

### DIFF
--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -159,14 +159,13 @@ class CompressedTensorModel(TensorModel):
     @model_validator(mode="after")
     def check_sizes(self):
         """Cross-validate that all sizes are consistent."""
-        raw = pybase64.b64encode(zlib.decompress(pybase64.b64decode(self.data)))
+        raw = zlib.decompress(pybase64.b64decode(self.data))
         elem_size = self._ELEM_SIZE_LOOKUP[self.dtype]
-        # each character encodes 6 bits, each set of 4 characters is therefore 3 bytes
-        # finally, suffixed with `=` to force a whole number of bytes.
-        len_data = (len(raw) // 4) * 3 - raw[-2:].count(b"=")
+        len_data = len(raw)
+
         if math.ceil(math.prod(self.shape) * elem_size) != len_data:
             raise ValueError(
-                f"Data length {len(raw)} is inconsistent with shape {self.shape} packed at "
+                f"Data length {len_data} is inconsistent with shape {self.shape} packed at "
                 f"{elem_size} bytes per element."
             )
         return self

--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -159,9 +159,12 @@ class CompressedTensorModel(TensorModel):
     @model_validator(mode="after")
     def check_sizes(self):
         """Cross-validate that all sizes are consistent."""
-        raw = zlib.decompress(pybase64.b64decode(self.data))
+        raw = pybase64.b64encode(zlib.decompress(pybase64.b64decode(self.data)))
         elem_size = self._ELEM_SIZE_LOOKUP[self.dtype]
-        if math.ceil(len(raw) / elem_size) != math.prod(self.shape):
+        # each character encodes 6 bits, each set of 4 characters is therefore 3 bytes
+        # finally, suffixed with `=` to force a whole number of bytes.
+        len_data = (len(raw) // 4) * 3 - raw[-2:].count(b"=")
+        if math.ceil(math.prod(self.shape) * elem_size) != len_data:
             raise ValueError(
                 f"Data length {len(raw)} is inconsistent with shape {self.shape} packed at "
                 f"{elem_size} bytes per element."

--- a/test/common/test_tensor.py
+++ b/test/common/test_tensor.py
@@ -83,6 +83,15 @@ class TestCompressedTensorModel:
         with pytest.raises(ValueError, match="Unexpected NumPy dtype 'int64'"):
             CompressedTensorModel.from_numpy(array)
 
+    def test_bool_array(self):
+        """Test that bool arrays work correctly."""
+        array = np.array([[False], [True], [True]])
+        encoded = CompressedTensorModel.from_numpy(array)
+        array_out = encoded.to_numpy()
+
+        assert np.all(array == array_out)
+        assert array.dtype == array_out.dtype
+
 
 class TestF64CompressedTensorModel:
     """Tests for ``F64CompressedTensorModel``."""


### PR DESCRIPTION
### Summary
Currently
```
bool_array = np.array([[False], [True], [True]])
CompressedTensorModel.from_numpy(bool_array)
```
will fail at the `check_sizes` step due to a minor difference versus `TensorModel`'s implementation. This PR updates `check_sizes` to match the validation of `TensorModel`.

### Details and comments
Fixes #176 
