### PR TITLE
Remove `TensorModel` from types allowed for passthrough data of executor schemas 2.0

### DIFF
--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -28,7 +28,6 @@ from ibm_quantum_schemas.common import (
     CompressedTensorModel,
     F64CompressedTensorModel,
     PauliLindbladMapModel,
-    TensorModel,
 )
 from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 
@@ -39,7 +38,6 @@ from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 DataTree = TypeAliasType(
     "DataTree",
     list["DataTree"]
-    | TensorModel
     | CompressedTensorModel
     | dict[str, "DataTree"]
     | str


### PR DESCRIPTION
### Summary
This PR addressed a comment in PR #170 and finalizes issue #159.
In particular, it removes `TensorModel` from types allowed for passthrough data, leaving `CompressedTensorModel` as the only valid field