### PR TITLE
Executor v2.0 - `CompressedQpyDataModel` custom encoder / decoder

### DIFF
--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -179,13 +179,10 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
 
         Args:
             use_cached: Whether to return the cached instance (if it exists).
-            metadata_deserializer: An optional JSONDecoder class
-                that will be used for the ``cls`` kwarg on the internal
-                ``json.load`` call used to deserialize the JSON payload used for
-                the ``.metadata`` attribute for any programs in the QPY file.
-                If this is not specified the circuit metadata will
-                be parsed as JSON with the stdlib ``json.load()`` function using
-                the default ``JSONDecoder`` class.
+            metadata_deserializer: An optional :class:`json.JSONDecoder` class
+                that will be forwarded to :func:`qiskit.qpy.load`` when deserializing QPY data.
+                In particular, this controls how JSON-serialized circuit metadata are 
+                instantiated into Python objects at load time.
 
         Returns:
             Python data.

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -181,7 +181,7 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
             use_cached: Whether to return the cached instance (if it exists).
             metadata_deserializer: An optional :class:`json.JSONDecoder` class
                 that will be forwarded to :func:`qiskit.qpy.load`` when deserializing QPY data.
-                In particular, this controls how JSON-serialized circuit metadata are 
+                In particular, this controls how JSON-serialized circuit metadata are
                 instantiated into Python objects at load time.
 
         Returns:
@@ -217,7 +217,7 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
             qpy_version: The QPY version to encode with.
             metadata_serializer: An optional :class:`json.JSONEncoder` class that
                 will be passed to :func:`qiskit.qpy.dump` during QPY serialization. In particular,
-                this encoder overrides the default behaviour of converting Python objects 
+                this encoder overrides the default behaviour of converting Python objects
                 into JSON data.
 
         Returns:

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -16,6 +16,7 @@ import struct
 import zlib
 from dataclasses import dataclass
 from io import BytesIO
+from json import JSONDecoder, JSONEncoder
 from typing import Generic, TypeVar
 
 from pybase64 import b64decode, b64encode
@@ -167,7 +168,9 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
             )
         return self
 
-    def to_python(self, use_cached: bool = False) -> list[T]:
+    def to_python(
+        self, use_cached: bool = False, metadata_deserializer: type[JSONDecoder] | None = None
+    ) -> list[T]:
         """Return a Python representation of the encoded data in the model.
 
         When ``use_cached`` is false, or when no cached version exists, :attr:`~b64_data` is
@@ -176,6 +179,13 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
 
         Args:
             use_cached: Whether to return the cached instance (if it exists).
+            metadata_deserializer: An optional JSONDecoder class
+                that will be used for the ``cls`` kwarg on the internal
+                ``json.load`` call used to deserialize the JSON payload used for
+                the ``.metadata`` attribute for any programs in the QPY file.
+                If this is not specified the circuit metadata will
+                be parsed as JSON with the stdlib ``json.load()`` function using
+                the default ``JSONDecoder`` class.
 
         Returns:
             Python data.
@@ -183,12 +193,21 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
         if not use_cached or not hasattr(self, "_python_data"):
             raw_data = zlib.decompress(b64decode(self.b64_data))
             with BytesIO(raw_data) as bytes_obj:
-                self._python_data = load(bytes_obj, annotation_factories=ANNOTATION_FACTORIES)
+                self._python_data = load(
+                    bytes_obj,
+                    metadata_deserializer=metadata_deserializer,
+                    annotation_factories=ANNOTATION_FACTORIES,
+                )
 
         return self._python_data
 
     @classmethod
-    def from_python(cls, data: list[T], qpy_version: int = QPY_VERSION) -> Self:
+    def from_python(
+        cls,
+        data: list[T],
+        qpy_version: int = QPY_VERSION,
+        metadata_serializer: type[JSONEncoder] | None = None,
+    ) -> Self:
         """Create a model instance from Python data of the correct type.
 
         The returned instance owns a reference to the provided data. This instance may be
@@ -199,12 +218,22 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
         Args:
             data: The data to base64 encode in the new model instance.
             qpy_version: The QPY version to encode with.
+            metadata_serializer: An optional JSONEncoder class that
+                will be passed the ``.metadata`` attribute for each program in ``programs`` and will
+                be used as the ``cls`` kwarg on the `json.dump()`` call to JSON serialize that
+                dictionary.
 
         Returns:
             A new model instance.
         """
         with BytesIO() as bytes_obj:
-            dump(data, bytes_obj, version=qpy_version, annotation_factories=ANNOTATION_FACTORIES)
+            dump(
+                data,
+                bytes_obj,
+                version=qpy_version,
+                metadata_serializer=metadata_serializer,
+                annotation_factories=ANNOTATION_FACTORIES,
+            )
             raw_data = zlib.compress(bytes_obj.getvalue())
             b64_data = b64encode(raw_data).decode("utf-8")
 

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -215,10 +215,10 @@ class CompressedQpyDataModel(QpyDataModel[T], Generic[T]):
         Args:
             data: The data to base64 encode in the new model instance.
             qpy_version: The QPY version to encode with.
-            metadata_serializer: An optional JSONEncoder class that
-                will be passed the ``.metadata`` attribute for each program in ``programs`` and will
-                be used as the ``cls`` kwarg on the `json.dump()`` call to JSON serialize that
-                dictionary.
+            metadata_serializer: An optional :class:`json.JSONEncoder` class that
+                will be passed to :func:`qiskit.qpy.dump` during QPY serialization. In particular,
+                this encoder overrides the default behaviour of converting Python objects 
+                into JSON data.
 
         Returns:
             A new model instance.

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -12,7 +12,10 @@
 
 """Tests for QPY models."""
 
+from dataclasses import dataclass
 from io import BytesIO
+from json import JSONDecoder, JSONEncoder
+from typing import Any
 from zlib import compress
 
 import pytest
@@ -256,3 +259,66 @@ class TestCompressedQpyDataV13ToV17Model:
 
         with pytest.raises(ValueError):
             CompressedQpyDataV13ToV17Model.from_python([circuit], qpy_version)
+
+    @pytest.mark.skip_if_qiskit_too_old_for_qpy
+    @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
+    def test_custom_serializers(self, qpy_version):
+        """Test that custom serializers work correctly."""
+
+        @dataclass
+        class Foo:
+            """Custom metadata class for testing."""
+
+            val: int
+
+        class FooEncoder(JSONEncoder):
+            """Called to encode `Foo` object."""
+
+            def default(self, obj: Any) -> Any:
+                if isinstance(obj, Foo):
+                    out_val = {
+                        "val": obj.val,
+                    }
+                    return {"__type__": "Foo", "__value__": out_val}
+                return super().default(obj)
+
+        class FooDecoder(JSONDecoder):
+            """Called to decode `Foo` object."""
+
+            def __init__(self, *args: Any, **kwargs: Any):
+                super().__init__(object_hook=self.object_hook, *args, **kwargs)
+
+            def object_hook(self, obj: Any) -> Any:
+                if "__type__" in obj:
+                    obj_type = obj["__type__"]
+                    obj_val = obj["__value__"]
+                    if obj_type == "Foo":
+                        return Foo(**obj_val)
+                return obj
+
+        metadata = {"experiment_type": Foo(1)}
+
+        circuit0 = QuantumCircuit(3, metadata=metadata)
+        circuit0.h(0)
+        circuit0.cx(0, 1)
+        circuit0.measure_all()
+
+        with pytest.raises(TypeError, match="Object of type Foo is not JSON serializable"):
+            encoded = CompressedQpyDataV13ToV17Model.from_python(
+                [circuit0],
+                qpy_version,
+            )
+
+        encoded = CompressedQpyDataV13ToV17Model.from_python(
+            [circuit0],
+            qpy_version,
+            metadata_serializer=FooEncoder,
+        )
+
+        assert encoded.num_programs == 1
+        assert encoded.qpy_version == qpy_version
+
+        (circuit0_out,) = encoded.to_python(metadata_deserializer=FooDecoder)
+
+        assert circuit0 == circuit0_out
+        assert circuit0.metadata == circuit0_out.metadata


### PR DESCRIPTION
### Summary
`qiskit.qpy` supports a custom JSON encoder and decoder to be passed in for handling custom metadata embedded in your `QuantumCircuit`. Our `CompressedQpyDataModel` helper methods should expose this feature to users.


### Details and comments
Closes #174 
