### PR TITLE
Executor v2.0 - Unconstrained SSV and QPY Models

### DIFF
--- a/ibm_quantum_schemas/common/__init__.py
+++ b/ibm_quantum_schemas/common/__init__.py
@@ -32,7 +32,6 @@ Classes
    QpyModelV13ToV16
    QpyModelV13ToV17
    CompressedQpyDataModel
-   CompressedQpyDataV13ToV17Model
    BaseParamsModel
    PauliLindbladMapModel
    SamplexModel
@@ -48,7 +47,6 @@ from ibm_quantum_schemas.common.base_params import BaseParamsModel
 from ibm_quantum_schemas.common.pauli_lindblad_map import PauliLindbladMapModel
 from ibm_quantum_schemas.common.qpy import (
     CompressedQpyDataModel,
-    CompressedQpyDataV13ToV17Model,
     QpyDataModel,
     QpyDataV13ToV17Model,
     QpyModel,

--- a/ibm_quantum_schemas/common/qpy.py
+++ b/ibm_quantum_schemas/common/qpy.py
@@ -327,9 +327,3 @@ class QpyDataV13ToV17Model(QpyDataModel[T], Generic[T]):
     """QPY encoded circuit list with restricted version range."""
 
     qpy_version: int = Field(ge=13, le=17)
-
-
-class CompressedQpyDataV13ToV17Model(CompressedQpyDataModel[T], Generic[T]):
-    """Compressed QPY encoded circuit list with restricted version range."""
-
-    qpy_version: int = Field(ge=13, le=17)

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -28,8 +28,8 @@ from ibm_quantum_schemas.common import (
     CompressedTensorModel,
     F64CompressedTensorModel,
     PauliLindbladMapModel,
+    SamplexModel,
 )
-from ibm_quantum_schemas.common import SamplexModelSSV1ToSSV4 as SamplexModel
 
 # TypeAliasType is required for Pydantic to handle this recursive type correctly.
 # Note that TypeAliasType is a backport for Python<3.12, so that when drop Python 3.11 support and

--- a/ibm_quantum_schemas/executor/version_2_0_dev/models.py
+++ b/ibm_quantum_schemas/executor/version_2_0_dev/models.py
@@ -24,7 +24,7 @@ from typing_extensions import TypeAliasType
 from ibm_quantum_schemas.aliases import Self
 from ibm_quantum_schemas.common import (
     BaseParamsModel,
-    CompressedQpyDataV13ToV17Model,
+    CompressedQpyDataModel,
     CompressedTensorModel,
     F64CompressedTensorModel,
     PauliLindbladMapModel,
@@ -168,7 +168,7 @@ class QuantumProgramModel(BaseModel):
     shots: int = Field(ge=1)
     """The number of shots for each individually bound circuit."""
 
-    circuits: CompressedQpyDataV13ToV17Model[QuantumCircuit]
+    circuits: CompressedQpyDataModel[QuantumCircuit]
     """One quantum circuit for every element of ``items``.
 
     These are stored outside of ``items`` to cosituate them inside of one QPY blob.

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -25,7 +25,7 @@ from qiskit.qpy import dump
 from samplomatic import ChangeBasis, InjectNoise, Twirl
 
 from ibm_quantum_schemas.common.qpy import (
-    CompressedQpyDataV13ToV17Model,
+    CompressedQpyDataModel,
     QpyDataV13ToV17Model,
     QpyModelV13ToV16,
     QpyModelV13ToV17,
@@ -199,8 +199,8 @@ class TestQpyDataV13ToV17Model:
             QpyDataV13ToV17Model.from_python([circuit], qpy_version)
 
 
-class TestCompressedQpyDataV13ToV17Model:
-    """Tests for ``CompressedQpyDataV13ToV17Model``."""
+class TestCompressedQpyDataModel:
+    """Tests for ``CompressedQpyDataModel``."""
 
     @pytest.mark.skip_if_qiskit_too_old_for_qpy
     @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
@@ -217,7 +217,7 @@ class TestCompressedQpyDataV13ToV17Model:
 
         circuits = [circuit0, circuit1]
 
-        encoded = CompressedQpyDataV13ToV17Model.from_python(
+        encoded = CompressedQpyDataModel.from_python(
             circuits,
             qpy_version,
         )
@@ -240,7 +240,7 @@ class TestCompressedQpyDataV13ToV17Model:
             circuit.cx(1, 2)
         circuit.measure_all()
 
-        encoded = CompressedQpyDataV13ToV17Model.from_python(
+        encoded = CompressedQpyDataModel.from_python(
             [circuit],
             qpy_version,
         )
@@ -258,7 +258,7 @@ class TestCompressedQpyDataV13ToV17Model:
         circuit.measure_all()
 
         with pytest.raises(ValueError):
-            CompressedQpyDataV13ToV17Model.from_python([circuit], qpy_version)
+            CompressedQpyDataModel.from_python([circuit], qpy_version)
 
     @pytest.mark.skip_if_qiskit_too_old_for_qpy
     @pytest.mark.parametrize("qpy_version", [13, 14, 15, 16, 17])
@@ -304,12 +304,12 @@ class TestCompressedQpyDataV13ToV17Model:
         circuit0.measure_all()
 
         with pytest.raises(TypeError, match="Object of type Foo is not JSON serializable"):
-            encoded = CompressedQpyDataV13ToV17Model.from_python(
+            encoded = CompressedQpyDataModel.from_python(
                 [circuit0],
                 qpy_version,
             )
 
-        encoded = CompressedQpyDataV13ToV17Model.from_python(
+        encoded = CompressedQpyDataModel.from_python(
             [circuit0],
             qpy_version,
             metadata_serializer=FooEncoder,

--- a/test/executor/version_2_0_dev/test_models.py
+++ b/test/executor/version_2_0_dev/test_models.py
@@ -19,7 +19,7 @@ import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 from samplomatic import Twirl, build
 
-from ibm_quantum_schemas.common.qpy import CompressedQpyDataV13ToV17Model as QpyDataModel
+from ibm_quantum_schemas.common.qpy import CompressedQpyDataModel as QpyDataModel
 from ibm_quantum_schemas.common.samplex import SamplexModel
 from ibm_quantum_schemas.common.tensor import CompressedTensorModel, F64CompressedTensorModel
 from ibm_quantum_schemas.executor.version_2_0_dev import (

--- a/test/executor/version_2_0_dev/test_models.py
+++ b/test/executor/version_2_0_dev/test_models.py
@@ -20,7 +20,7 @@ from qiskit.circuit import Parameter, QuantumCircuit
 from samplomatic import Twirl, build
 
 from ibm_quantum_schemas.common.qpy import CompressedQpyDataV13ToV17Model as QpyDataModel
-from ibm_quantum_schemas.common.samplex import SamplexModelSSV1ToSSV4 as SamplexModel
+from ibm_quantum_schemas.common.samplex import SamplexModel
 from ibm_quantum_schemas.common.tensor import CompressedTensorModel, F64CompressedTensorModel
 from ibm_quantum_schemas.executor.version_2_0_dev import (
     ChunkPart,


### PR DESCRIPTION
### Summary
Switching to unconstrained SSV and QPY models in the Executor schema


### Details and comments
Closes #160 
