### PR TITLE
Executor v2 using NumPy scalar `bool_`

### DIFF
--- a/ibm_quantum_schemas/common/tensor.py
+++ b/ibm_quantum_schemas/common/tensor.py
@@ -29,7 +29,7 @@ SupportedDtypesExtended: TypeAlias = Literal[
 """The data types supported by :class:`~CompressedTensorModel`."""
 
 SUPPORTED_DTYPE_EXTENDED_MAP: dict[np.dtype, SupportedDtypesExtended] = {
-    np.dtype(np.bool): "bool",
+    np.dtype(np.bool_): "bool",
     np.dtype(np.float16): "f16",
     np.dtype(np.float32): "f32",
     np.dtype(np.float64): "f64",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "qiskit>=2.2.0,<3.0.0",
     "qiskit_qasm3_import>=0.5.0,<1.0.0",
     "samplomatic>=0.12.0",
-    "pybase64>=1.3.0"
+    "numpy>=1.26.2",
+    "pybase64>=1.3.0",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
### Summary

Our minimal supported NumPy version is `1.26.0` where any version of Numpy < 2 deprecates the dtype `np.bool` (later reintroduced in v2.0). To avoid a deprecation warning for older NumPy versions we should instead use `np.bool_` which is the recommended scalar type.


### Details and comments
Fixes #186 
