### PR TITLE
Add support for `Tag` in `AnnotationSerializer`

### DIFF
--- a/ibm_quantum_schemas/common/annotation_serializer.py
+++ b/ibm_quantum_schemas/common/annotation_serializer.py
@@ -19,7 +19,7 @@ from types import NotImplementedType
 from typing import Any, cast
 
 from qiskit.circuit.annotation import Annotation, OpenQASM3Serializer, QPYSerializer
-from samplomatic.annotations import ChangeBasis, InjectNoise, Twirl
+from samplomatic.annotations import ChangeBasis, InjectNoise, Tag, Twirl
 from samplomatic.annotations.change_basis_mode import ChangeBasisLiteral
 from samplomatic.annotations.decomposition_mode import DecompositionLiteral
 from samplomatic.annotations.dressing_mode import DressingLiteral
@@ -38,6 +38,10 @@ CHANGE_BASIS_ANNOTATION = namedtuple(
 INJECT_NOISE_ANNOTATION_PACK = "!QQ"
 INJECT_NOISE_ANNOTATION_SIZE = struct.calcsize(INJECT_NOISE_ANNOTATION_PACK)
 INJECT_NOISE_ANNOTATION = namedtuple("INJECT_NOISE_ANNOTATION", ["ref_size", "modifier_ref_size"])
+
+TAG_ANNOTATION_PACK = "!Q"
+TAG_ANNOTATION_SIZE = struct.calcsize(TAG_ANNOTATION_PACK)
+TAG_ANNOTATION = namedtuple("TAG_ANNOTATION", ["ref_size"])
 
 TWIRL_ANNOTATION_PACK = "!QQQ"
 TWIRL_ANNOTATION_SIZE = struct.calcsize(TWIRL_ANNOTATION_PACK)
@@ -74,6 +78,10 @@ class AnnotationSerializer(QPYSerializer):
             modifier_ref = annotation.modifier_ref.encode()
             annotation_raw = struct.pack(INJECT_NOISE_ANNOTATION_PACK, len(ref), len(modifier_ref))
             return samplomatic_annotation + annotation_raw + ref + modifier_ref
+        if isinstance(annotation, Tag):
+            ref = annotation.ref.encode()
+            annotation_raw = struct.pack(TAG_ANNOTATION_PACK, len(ref))
+            return samplomatic_annotation + annotation_raw + ref
         if isinstance(annotation, Twirl):
             group = annotation.group.encode()
             dressing = annotation.dressing.encode()
@@ -117,6 +125,15 @@ class AnnotationSerializer(QPYSerializer):
             ref = buff.read(inject_noise.ref_size).decode()
             modifier_ref = buff.read(inject_noise.modifier_ref_size).decode()
             return InjectNoise(ref, modifier_ref)
+        if name == "Tag":
+            tag = TAG_ANNOTATION._make(
+                struct.unpack(
+                    TAG_ANNOTATION_PACK,
+                    buff.read(TAG_ANNOTATION_SIZE),
+                )
+            )
+            ref = buff.read(tag.ref_size).decode()
+            return Tag(ref)
         if name == "Twirl":
             twirl = TWIRL_ANNOTATION._make(
                 struct.unpack(TWIRL_ANNOTATION_PACK, buff.read(TWIRL_ANNOTATION_SIZE))
@@ -155,6 +172,10 @@ class OpenQASM3AnnotationSerializer(OpenQASM3Serializer):
             modifier_ref = annotation.modifier_ref.encode()
             annotation_raw = struct.pack(INJECT_NOISE_ANNOTATION_PACK, len(ref), len(modifier_ref))
             return (samplomatic_annotation + annotation_raw + ref + modifier_ref).decode()
+        if isinstance(annotation, Tag):
+            ref = annotation.ref.encode()
+            annotation_raw = struct.pack(TAG_ANNOTATION_PACK, len(ref))
+            return (samplomatic_annotation + annotation_raw + ref).decode()
         if isinstance(annotation, Twirl):
             group = annotation.group.encode()
             dressing = annotation.dressing.encode()
@@ -200,6 +221,15 @@ class OpenQASM3AnnotationSerializer(OpenQASM3Serializer):
             ref = buff.read(inject_noise.ref_size).decode()
             modifier_ref = buff.read(inject_noise.modifier_ref_size).decode()
             return InjectNoise(ref, modifier_ref)
+        if name == "Tag":
+            tag = TAG_ANNOTATION._make(
+                struct.unpack(
+                    TAG_ANNOTATION_PACK,
+                    buff.read(TAG_ANNOTATION_SIZE),
+                )
+            )
+            ref = buff.read(tag.ref_size).decode()
+            return Tag(ref)
         if name == "Twirl":
             twirl = TWIRL_ANNOTATION._make(
                 struct.unpack(TWIRL_ANNOTATION_PACK, buff.read(TWIRL_ANNOTATION_SIZE))

--- a/test/common/test_annotation_serializer.py
+++ b/test/common/test_annotation_serializer.py
@@ -12,7 +12,7 @@
 
 """Tests for annotation serializers."""
 
-from samplomatic import ChangeBasis, InjectNoise, Twirl
+from samplomatic import ChangeBasis, InjectNoise, Tag, Twirl
 
 from ibm_quantum_schemas.common.annotation_serializer import (
     AnnotationSerializer,
@@ -48,6 +48,27 @@ class TestInjectNoise:
         """Test that round trips work correctly."""
         annotation = InjectNoise("ref")
         namespace = "samplomatic.inject_noise"
+
+        qpy_serializer = AnnotationSerializer()
+        payload = qpy_serializer.dump_annotation(namespace, annotation)
+        annotation_out = qpy_serializer.load_annotation(payload)
+
+        assert annotation == annotation_out
+
+        qasm_serializer = OpenQASM3AnnotationSerializer()
+        payload = qasm_serializer.dump(annotation)
+        annotation_out = qasm_serializer.load("", payload)
+
+        assert annotation == annotation_out
+
+
+class TestTag:
+    """Tests for ``Tag``."""
+
+    def test_roundtrip(self):
+        """Test that round trips work correctly."""
+        annotation = Tag("ref")
+        namespace = "samplomatic.tag"
 
         qpy_serializer = AnnotationSerializer()
         payload = qpy_serializer.dump_annotation(namespace, annotation)

--- a/test/common/test_qasm.py
+++ b/test/common/test_qasm.py
@@ -13,7 +13,7 @@
 """Tests for OpenQASM3 models."""
 
 from qiskit.circuit import Parameter, QuantumCircuit
-from samplomatic import ChangeBasis, InjectNoise, Twirl
+from samplomatic import ChangeBasis, InjectNoise, Tag, Twirl
 
 from ibm_quantum_schemas.common.qasm import OpenQasm3DataModel
 
@@ -51,7 +51,7 @@ class TestOpenQasm3DataModel:
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.cx(0, 1)
-        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis(), Tag("ref2")]):
             circuit.cx(1, 2)
         circuit.measure_all()
 

--- a/test/common/test_qpy.py
+++ b/test/common/test_qpy.py
@@ -22,7 +22,7 @@ import pytest
 from pybase64 import b64encode
 from qiskit.circuit import QuantumCircuit
 from qiskit.qpy import dump
-from samplomatic import ChangeBasis, InjectNoise, Twirl
+from samplomatic import ChangeBasis, InjectNoise, Tag, Twirl
 
 from ibm_quantum_schemas.common.qpy import (
     CompressedQpyDataModel,
@@ -77,7 +77,7 @@ class TestQpyModelV13ToV16:
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.cx(0, 1)
-        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis(), Tag("ref2")]):
             circuit.cx(1, 2)
         circuit.measure_all()
 
@@ -122,7 +122,7 @@ class TestQpyModelV13ToV17:
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.cx(0, 1)
-        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis(), Tag("ref2")]):
             circuit.cx(1, 2)
         circuit.measure_all()
 
@@ -177,7 +177,7 @@ class TestQpyDataV13ToV17Model:
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.cx(0, 1)
-        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis(), Tag("ref2")]):
             circuit.cx(1, 2)
         circuit.measure_all()
 
@@ -236,7 +236,7 @@ class TestCompressedQpyDataModel:
         circuit = QuantumCircuit(3)
         circuit.h(0)
         circuit.cx(0, 1)
-        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis()]):
+        with circuit.box([Twirl(), InjectNoise("ref"), ChangeBasis(), Tag("ref2")]):
             circuit.cx(1, 2)
         circuit.measure_all()
 


### PR DESCRIPTION
### Summary
Add support for tags in the annotation serializer + tests 


### Details and comments
Closes #192 
