### PR TITLE
Bump samplomatic to minimum version 0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic>=2.11,<3.0.0",
     "qiskit>=2.2.0,<3.0.0",
     "qiskit_qasm3_import>=0.5.0,<1.0.0",
-    "samplomatic>=0.12.0",
+    "samplomatic>=0.17.0",
     "numpy>=1.26.2",
     "pybase64>=1.3.0",
 ]


### PR DESCRIPTION
### Summary
https://github.com/Qiskit/ibm-quantum-schemas/pull/193 added support for `Tag` in our annotation serializer however `Tag` was not included until `samplomatic` version `0.17.0`


### Details and comments
Follow up to #192 
